### PR TITLE
ci(docs): add wiki sync workflow (inherited by all template-derived libraries)

### DIFF
--- a/.github/workflows/sync-docs-to-wiki.yml
+++ b/.github/workflows/sync-docs-to-wiki.yml
@@ -1,0 +1,51 @@
+# Mirror docs/ → GitHub Wiki on every push to development.
+#
+# Pre-requisite (one-time per consumer repo — must be done in GitHub UI):
+#   1. Settings → Features → Wikis (checkbox enabled)
+#   2. Create the first Wiki page (any content — e.g. "Home" with "TBD"). This
+#      step initializes the underlying `<repo>.wiki.git`. Without it, the sync
+#      action below fails with `Repository not found` because GitHub doesn't
+#      create the wiki repo until the first page exists.
+#
+# After that, every push to development that touches docs/** publishes the
+# updated tree to the wiki. The wiki tree mirrors docs/ verbatim:
+#   docs/Home.md                              → Wiki Home page
+#   docs/_Sidebar.md                          → Wiki Sidebar
+#   docs/getting-started/installation.md      → Wiki page at /getting-started/installation
+#   …etc.
+#
+# Manual dispatch is also supported for ad-hoc syncs.
+#
+# This workflow ships in mbl-library-template-kmp so every child library
+# inherits it via `customizer.sh` or template GitHub copy. No per-repo edits
+# needed — just enable the wiki once in the GitHub UI.
+
+name: Sync docs to Wiki
+
+on:
+  push:
+    branches:
+      - development
+    paths:
+      - 'docs/**'
+      - '.github/workflows/sync-docs-to-wiki.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Mirror docs/ → wiki
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push docs/ to wiki
+        uses: Andrew-Chen-Wang/github-wiki-action@v4
+        with:
+          path: docs
+          # Default branch of the wiki repo is `master`; keep that to avoid
+          # creating a second branch.
+          default-branch: master
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/sync-docs-to-wiki.yml` — mirrors `docs/` to the consumer repo's GitHub Wiki on every push to `development` that touches `docs/**` (plus manual dispatch). Every library scaffolded from this template inherits the workflow automatically.

Companion PR: [MobileByteLabs/worker-kmp#23](https://github.com/MobileByteLabs/worker-kmp/pull/23) adds the same workflow to worker-kmp directly. This PR back-ports it into the template source so future template consumers + `sync-dirs.sh`/`customizer.sh` sync targets pick it up.

## How it works

Uses [`Andrew-Chen-Wang/github-wiki-action@v4`](https://github.com/Andrew-Chen-Wang/github-wiki-action) — popular, maintained, authenticates with `GITHUB_TOKEN` (no PAT needed).

Tree maps directly:

| `docs/` path | Wiki page |
|---|---|
| `Home.md` | Home |
| `_Sidebar.md` | Sidebar |
| `getting-started/installation.md` | `/getting-started/installation` |
| `platform-support/android.md` | `/platform-support/android` |
| … | … |

## Pre-requisite (per consumer repo — one-time, GitHub UI)

GitHub doesn't create the `<repo>.wiki.git` repo until the wiki has at least one page:

1. **Settings → Features → Wikis** — enable the checkbox
2. **Wiki tab → Create the first page** — any content (e.g. a `Home` page with `TBD`) to initialize the underlying wiki repo

After that the workflow auto-syncs on every push to `development` that touches `docs/**`. Also dispatchable from Actions UI → "Sync docs to Wiki" → Run workflow.

## Test plan

- [x] YAML validates locally
- [ ] After merge: workflow itself doesn't run on this PR (template has no `docs/` yet), but child libraries that already have `docs/` (e.g. worker-kmp) will pick up the workflow via the next template sync round
- [ ] Verify on worker-kmp after [#23](https://github.com/MobileByteLabs/worker-kmp/pull/23) merges + wiki is bootstrapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)