### PR TITLE
ci(wiki): upgrade sync-docs-to-wiki workflow with link rewriter + collision-safe slugs

### DIFF
--- a/.claude/SYNC.md
+++ b/.claude/SYNC.md
@@ -42,6 +42,13 @@ syncable_files:
       - "on.release"
       - "env secrets"
     description: "Maven Central publish — multi-module auto-discovery + parallel"
+  - path: .github/workflows/sync-docs-to-wiki.yml
+    strategy: replace
+    description: "Mirror docs/ → GitHub Wiki — collision-safe link rewriter + smoke test"
+  - path: .github/scripts/rewrite-wiki-links.py
+    strategy: replace
+    executable: true
+    description: "Wiki link rewriter (called by sync-docs-to-wiki.yml). Portable — auto-derives wiki URL from $GITHUB_REPOSITORY or origin remote"
   - path: config/detekt/detekt.yml
     strategy: replace
     description: "Detekt static analysis configuration"

--- a/.github/scripts/rewrite-wiki-links.py
+++ b/.github/scripts/rewrite-wiki-links.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Pre-process docs/ for GitHub Wiki sync.
+
+Copy docs/ → .wiki-build/, rewriting internal `.md` links to absolute
+`/wiki/{basename}` URLs that GitHub Wiki actually resolves.
+
+Why this exists
+---------------
+GitHub Wiki indexes every `.md` file by its **basename** — the source
+subdirectory context is dropped when the wiki action mirrors `docs/`.
+That means relative links in the source docs break on the wiki:
+
+  ](sub-dir/file.md)  →  404, redirects to raw.githubusercontent.com
+  ](file.md)          →  200 but SILENT redirect to wiki Home
+
+This script rewrites those targets to absolute `/wiki/file` URLs that
+resolve correctly on the wiki. The source `docs/` tree stays untouched,
+so in-repo browsing of `docs/` continues to use relative links naturally.
+
+Scope rules
+-----------
+* Only rewrite if the resolved link target lives inside the source tree
+  (i.e., is a doc that will actually be published to the wiki). Out-of-tree
+  references like `../../build-logic/.../Plugin.kt` (.kt is ignored anyway)
+  or `../../../../plan-layer/.../GOAL.md` (lives outside docs/) stay
+  untouched.
+* Skip code fences (```…```) and inline code (`…`) so we don't rewrite
+  link-like substrings inside code samples.
+* Skip absolute URLs (http://, https://) — never rewrite an existing
+  external link.
+* Skip pure-anchor links like `(#section)` — anchor-only links stay
+  intact (they navigate within the current page).
+
+Wiki URL resolution (portable across repos)
+-------------------------------------------
+1. `$WIKI_BASE` env var if set (explicit override, useful for tests)
+2. `$GITHUB_REPOSITORY` env var (GitHub Actions sets this automatically)
+3. `git remote get-url origin` parsed (local dev fallback)
+4. Bail with a clear error message if none of the above resolves
+
+Usage: python3 rewrite-wiki-links.py SRC DST
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def resolve_wiki_base() -> str:
+    """Derive the wiki URL prefix for this repo."""
+    explicit = os.environ.get("WIKI_BASE")
+    if explicit:
+        return explicit.rstrip("/")
+
+    gh_repo = os.environ.get("GITHUB_REPOSITORY")  # set by GitHub Actions: "Owner/Repo"
+    if gh_repo:
+        return f"https://github.com/{gh_repo}/wiki"
+
+    try:
+        url = subprocess.check_output(
+            ["git", "remote", "get-url", "origin"], text=True
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        url = ""
+
+    # git@github.com:Owner/Repo.git → https://github.com/Owner/Repo/wiki
+    m = re.match(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$", url)
+    if m:
+        return f"https://github.com/{m.group(1)}/{m.group(2)}/wiki"
+    # https://github.com/Owner/Repo[.git] → https://github.com/Owner/Repo/wiki
+    m = re.match(r"https?://github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$", url)
+    if m:
+        return f"https://github.com/{m.group(1)}/{m.group(2)}/wiki"
+
+    print(
+        "❌ Cannot resolve wiki URL — set $WIKI_BASE or $GITHUB_REPOSITORY, "
+        "or run from a git repo with an origin remote on github.com",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+WIKI = resolve_wiki_base()
+
+
+def build_slug_map(tree_root: Path) -> dict[Path, str]:
+    """
+    Map every .md file in tree_root to its wiki slug.
+
+    Strategy: GitHub Wiki indexes by file basename. If two `.md` files share
+    a basename (`docs/bubble/README.md` + `docs/clipboard/README.md`), the
+    second overwrites the first on the wiki. To avoid that we detect
+    collisions and use subdir-prefixed slugs for the colliding files:
+
+      docs/Home.md                          → Home
+      docs/_Sidebar.md                      → _Sidebar
+      docs/installation.md                  → installation       (no collision)
+      docs/getting-started/installation.md  → installation       (no collision)
+      docs/bubble/README.md                 → bubble-README      (collision!)
+      docs/clipboard/README.md              → clipboard-README   (collision!)
+
+    Special wiki files (`Home`, `_Sidebar`, `_Footer`) at the docs root keep
+    their bare names regardless.
+    """
+    SPECIAL = {"Home", "_Sidebar", "_Footer"}
+    md_files = list(tree_root.rglob("*.md"))
+
+    # Count basename occurrences
+    counts: dict[str, int] = {}
+    for f in md_files:
+        counts[f.stem] = counts.get(f.stem, 0) + 1
+
+    slug_map: dict[Path, str] = {}
+    for f in md_files:
+        rel = f.relative_to(tree_root)
+        if rel.parent == Path(".") and f.stem in SPECIAL:
+            slug_map[f.resolve(strict=False)] = f.stem
+        elif counts[f.stem] == 1:
+            slug_map[f.resolve(strict=False)] = f.stem
+        else:
+            # Collision → use subdir-prefixed slug
+            parts = list(rel.parts[:-1]) + [f.stem]
+            slug_map[f.resolve(strict=False)] = "-".join(parts)
+    return slug_map
+
+
+LINK_RE = re.compile(
+    r"""
+    \]\(                              # opening of the link target
+      (?!https?://)                   # bail on absolute URLs
+      (?P<path>(?:[^)/\s]+/)*)        # optional relative path segments
+      (?P<basename>[A-Za-z0-9._-]+)   # filename without extension
+      \.md                            # require .md
+      (?P<anchor>\#[^)\s]+)?          # optional #anchor
+    \)
+    """,
+    re.VERBOSE,
+)
+
+# Spans we MUST NOT rewrite: code fences + inline code.
+PROTECT_RE = re.compile(r"```[\s\S]*?```|`[^`\n]+`")
+
+
+def rewrite(content: str, source_file: Path, tree_root: Path, slug_map: dict[Path, str]) -> str:
+    """Return `content` with in-tree .md links rewritten to wiki URLs."""
+    stash: list[str] = []
+
+    def _stash(m: re.Match) -> str:
+        stash.append(m.group(0))
+        return f"\0PROTECT{len(stash) - 1}\0"
+
+    stashed = PROTECT_RE.sub(_stash, content)
+
+    tree_root_abs = tree_root.resolve(strict=False)
+
+    def _rewrite(m: re.Match) -> str:
+        path = m.group("path") or ""
+        basename = m.group("basename")
+        anchor = m.group("anchor") or ""
+
+        target_abs = (source_file.parent / f"{path}{basename}.md").resolve(strict=False)
+        try:
+            target_abs.relative_to(tree_root_abs)
+        except ValueError:
+            # Outside the docs tree — leave the link as-is so repo browsing still works.
+            return m.group(0)
+
+        slug = slug_map.get(target_abs, basename)
+        return f"]({WIKI}/{slug}{anchor})"
+
+    rewritten = LINK_RE.sub(_rewrite, stashed)
+
+    for i, original in enumerate(stash):
+        rewritten = rewritten.replace(f"\0PROTECT{i}\0", original, 1)
+
+    return rewritten
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage: rewrite-wiki-links.py SRC DST", file=sys.stderr)
+        return 1
+
+    src = Path(sys.argv[1])
+    dst = Path(sys.argv[2])
+
+    if not src.is_dir():
+        print(f"Source dir not found: {src}", file=sys.stderr)
+        return 1
+
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)
+
+    # Phase 1 — Build the slug map from the ORIGINAL (still-nested) tree.
+    # This map keys absolute paths in dst → wiki slug. Used by the rewriter
+    # to translate `[text](sub/file.md)` link targets to `/wiki/{slug}` URLs.
+    slug_map = build_slug_map(dst)
+
+    # Phase 2 — Rewrite links inside each file. Resolves link targets against
+    # the original tree layout (subdirs still present), so [text](sub/file.md)
+    # in docs/Home.md correctly resolves to dst/sub/file.md → looks up
+    # slug "sub-file" → emits /wiki/sub-file.
+    changed = 0
+    for md_file in list(dst.rglob("*.md")):
+        before = md_file.read_text()
+        after = rewrite(before, md_file, dst, slug_map)
+        if after != before:
+            md_file.write_text(after)
+            changed += 1
+            print(f"rewrote: {md_file.relative_to(dst)}")
+
+    # Phase 3 — Flatten dst to top-level (wiki indexes by basename).
+    # Move dst/sub/file.md → dst/sub-file.md (slug-named).
+    for original_path, slug in slug_map.items():
+        rel = original_path.relative_to(dst.resolve(strict=False))
+        if str(rel) != f"{slug}.md":
+            target = dst / f"{slug}.md"
+            original_path.rename(target)
+
+    # Phase 4 — Drop empty subdirs left behind by the flatten.
+    for subdir in sorted(dst.rglob("*"), reverse=True):
+        if subdir.is_dir() and not any(subdir.iterdir()):
+            subdir.rmdir()
+
+    print(f"\nDone. {changed} file(s) had links rewritten. WIKI={WIKI}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/sync-docs-to-wiki.yml
+++ b/.github/workflows/sync-docs-to-wiki.yml
@@ -1,24 +1,29 @@
 # Mirror docs/ → GitHub Wiki on every push to development.
 #
-# Pre-requisite (one-time per consumer repo — must be done in GitHub UI):
+# Pre-requisite (one-time, must be done in GitHub UI):
 #   1. Settings → Features → Wikis (checkbox enabled)
 #   2. Create the first Wiki page (any content — e.g. "Home" with "TBD"). This
-#      step initializes the underlying `<repo>.wiki.git`. Without it, the sync
-#      action below fails with `Repository not found` because GitHub doesn't
-#      create the wiki repo until the first page exists.
+#      step initializes the underlying `{repo}.wiki.git` repo. Without it,
+#      the sync action below fails with `Repository not found`.
 #
-# After that, every push to development that touches docs/** publishes the
-# updated tree to the wiki. The wiki tree mirrors docs/ verbatim:
-#   docs/Home.md                              → Wiki Home page
-#   docs/_Sidebar.md                          → Wiki Sidebar
-#   docs/getting-started/installation.md      → Wiki page at /getting-started/installation
+# What this workflow does
+# -----------------------
+# 1. Run `.github/scripts/rewrite-wiki-links.py` to copy docs/ → .wiki-build/
+#    while rewriting internal `.md` links to absolute /wiki/{basename} URLs.
+#    GitHub Wiki indexes every .md by basename (subdir context dropped), so
+#    relative links like `[text](sub-dir/file.md)` and `[text](file.md)`
+#    BREAK on the wiki. The script fixes them.
+# 2. Run a smoke test to catch script regressions.
+# 3. Hand .wiki-build/ to the wiki sync action.
+#
+# Wiki layout: every doc lives at /wiki/{basename}. e.g.:
+#   docs/Home.md                      → /wiki/Home
+#   docs/_Sidebar.md                  → /wiki/_Sidebar
+#   docs/getting-started/install.md   → /wiki/install
+#   docs/features/notifications.md    → /wiki/notifications
 #   …etc.
 #
-# Manual dispatch is also supported for ad-hoc syncs.
-#
-# This workflow ships in mbl-library-template-kmp so every child library
-# inherits it via `customizer.sh` or template GitHub copy. No per-repo edits
-# needed — just enable the wiki once in the GitHub UI.
+# Manual dispatch is supported for ad-hoc syncs.
 
 name: Sync docs to Wiki
 
@@ -29,6 +34,7 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/sync-docs-to-wiki.yml'
+      - '.github/scripts/rewrite-wiki-links.py'
   workflow_dispatch:
 
 permissions:
@@ -41,11 +47,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Push docs/ to wiki
+      - name: Rewrite docs/ links → /wiki/ URLs (build .wiki-build/)
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 .github/scripts/rewrite-wiki-links.py docs .wiki-build
+
+      - name: Smoke test — rewrite produced expected output
+        run: |
+          # .wiki-build/ must exist and be non-empty
+          if [ ! -d .wiki-build ] || [ -z "$(ls -A .wiki-build)" ]; then
+            echo "::error::.wiki-build/ missing or empty — script failed silently"
+            exit 1
+          fi
+          # At least one rewritten link in any of the files (otherwise the script
+          # is broken OR docs/ has zero in-tree .md links — both worth a manual check).
+          # The smoke is best-effort: if docs/ legitimately has zero internal links
+          # this will fail; comment out in that case.
+          if ! grep -rqE "https://github\.com/.+/wiki/[A-Za-z0-9._-]+" .wiki-build/; then
+            echo "::warning::No rewritten /wiki/ links found in .wiki-build/. Either docs/ has zero in-tree .md links or the rewriter is broken."
+          fi
+          echo "Wiki build verified ✓"
+
+      - name: Push .wiki-build/ to wiki
         uses: Andrew-Chen-Wang/github-wiki-action@v4
         with:
-          path: docs
-          # Default branch of the wiki repo is `master`; keep that to avoid
-          # creating a second branch.
-          default-branch: master
+          path: .wiki-build
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This template's existing `sync-docs-to-wiki.yml` had three latent bugs that were discovered + fixed in worker-kmp during PRs [#32](https://github.com/MobileByteLabs/worker-kmp/pull/32) / [#34](https://github.com/MobileByteLabs/worker-kmp/pull/34) / [#35](https://github.com/MobileByteLabs/worker-kmp/pull/35) / [#41](https://github.com/MobileByteLabs/worker-kmp/pull/41). Bringing those fixes upstream so every future library inheriting from this template gets them.

## Bugs fixed

| # | Bug | Fix |
|---|---|---|
| 1 | `default-branch: master` input is invalid in `Andrew-Chen-Wang/github-wiki-action@v4` — every run emits a warning | Removed |
| 2 | `docs/sub-dir/file.md` doesn't resolve as a wiki URL — GitHub Wiki indexes every `.md` by **basename only**, so `[text](getting-started/installation.md)` 404s + falls back to `raw.githubusercontent.com` | New `.github/scripts/rewrite-wiki-links.py` rewrites all in-tree `.md` links to `/wiki/{slug}` URLs at sync time |
| 3 | Basename collisions silently overwrite — if `docs/bubble/README.md` + `docs/clipboard/README.md` both exist, the second wins on the wiki | Script detects collisions + slugifies with subdir prefix: `docs/bubble/README.md` → `/wiki/bubble-README`; bare basename otherwise |

## What ships in this PR

| File | Strategy |
|------|----------|
| `.github/workflows/sync-docs-to-wiki.yml` | Replaced (drops the buggy v3-shape) |
| `.github/scripts/rewrite-wiki-links.py` | **New** — portable Python rewriter; auto-derives wiki URL from `$GITHUB_REPOSITORY` (CI) / `git remote get-url origin` (local) — no per-repo hardcoding |
| `.claude/SYNC.md` | Both files registered as `strategy: replace` so `/lib-template-sync` propagates them to child libraries |

## Portability features (so the same script works for any consumer)

- Wiki URL auto-derivation: `$WIKI_BASE` env (override) → `$GITHUB_REPOSITORY` (CI) → `git remote get-url origin` parsed (local)
- Collision detection + safe slugification (subdir-prefix when needed, bare when not)
- Special wiki files (`Home`, `_Sidebar`, `_Footer`) at docs root keep bare names regardless
- Out-of-tree refs (e.g. `../../build-logic/Plugin.kt`) preserved verbatim
- Code fences + inline code + absolute URLs + pure-anchor links untouched

## Consumer rollout

Companion PRs already opened against the two consumers that needed the fix today:
- [`KmpToolkit#125`](https://github.com/MobileByteLabs/KmpToolkit/pull/125) — 3 basename collisions (`README.md` / `SETUP.md` / `CLAUDE_AI_SETUP.md` repeating across modules) → the collision-safe path is what actually unblocks this repo
- `kmp-product-flavors` — flat docs, no collisions, but still needs the link rewriter for cross-page navigation

After this template PR merges, future `/lib-template-sync` runs will pull these files into every child library automatically.

## Test plan

- [x] Both scripts shellcheck/python-syntax clean
- [x] Local smoke against KmpToolkit's docs/ → 31 files rewritten, all collisions slugified, all bare slugs unique
- [x] Local smoke against kmp-product-flavors's docs/ → 18 files rewritten, 33 flat outputs (no collisions)
- [ ] After merge: consumers run `/lib-template-sync` to inherit
- [ ] One-time human bootstrap per consumer: Wiki tab → "Create the first page" (workflow header documents this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)