### PR TITLE
chore(wiki): retarget caller to mbl-actionhub@v1.8.0

### DIFF
--- a/.github/workflows/sync-docs-to-wiki.yml
+++ b/.github/workflows/sync-docs-to-wiki.yml
@@ -1,5 +1,6 @@
-# Mirror docs/ → GitHub Wiki via the reusable workflow in mbl-actionhub-docshub.
-# Logic lives in mbl-actionhub-docshub@v0.1.0; this file only configures triggers.
+# Mirror docs/ → GitHub Wiki via the reusable workflow in mbl-actionhub.
+# Logic lives in mbl-actionhub@v1.8.0 → mbl-actionhub-docshub@v0.2.0;
+# this file only configures triggers.
 
 name: Sync docs to Wiki
 
@@ -17,4 +18,4 @@ permissions:
 
 jobs:
   sync:
-    uses: MobileByteLabs/mbl-actionhub-docshub/.github/workflows/sync-docs-to-wiki.yml@v0.1.0
+    uses: MobileByteLabs/mbl-actionhub/.github/workflows/sync-docs-to-wiki.yml@v1.8.0


### PR DESCRIPTION
## Summary

Re-pins the wiki-sync caller from the obsolete `mbl-actionhub-docshub@v0.1.0` (which was the reusable-workflow shape, since deprecated) to the new `mbl-actionhub@v1.8.0` entry point.

## Why

mbl-actionhub-docshub was repackaged from a reusable workflow → composite action in [mbl-actionhub-docshub#1](https://github.com/MobileByteLabs/mbl-actionhub-docshub/pull/1) (released as `v0.2.0`). The composite is now consumed BY mbl-actionhub's new reusable workflow at `v1.8.0` (released today).

This matches the established pattern where `mbl-actionhub-*` repos are composite actions internally used by mbl-actionhub's reusable workflows (same as `mbl-actionhub-bump-version` / `mbl-actionhub-resolve-version`).

## Diff

```diff
-    uses: MobileByteLabs/mbl-actionhub-docshub/.github/workflows/sync-docs-to-wiki.yml@v0.1.0
+    uses: MobileByteLabs/mbl-actionhub/.github/workflows/sync-docs-to-wiki.yml@v1.8.0
```

`.claude/SYNC.md` description updated to match (consumers pulling via `/lib-template-sync` get the corrected pin).

## Verified e2e

KmpToolkit's `development` already pins `@v1.8.0` (correctly from PR #127). Manual workflow dispatch ran successfully right before this PR was opened:
- [Run 26810524394](https://github.com/MobileByteLabs/KmpToolkit/actions/runs/26810524394) → success
- Wiki published 43 pages + auto-`_Sidebar.md` with 14 module sections
- See: https://github.com/MobileByteLabs/KmpToolkit/wiki/_Sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)