### PR TITLE
feat(docs): add mkdocs scaffold + customizer.sh wiring

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,24 @@
+name: Publish docs (mkdocs → GitHub Pages)
+
+# Delegates to the reusable workflow in mbl-actionhub. The mkdocs build
+# + Pages deploy logic lives there as a single source of truth across
+# every MobileByteLabs KMP library that publishes documentation.
+# Repo Pages source must be set to "GitHub Actions" (build_type=workflow).
+
+on:
+  push:
+    branches: [development]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs-publish.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  publish:
+    uses: MobileByteLabs/mbl-actionhub/.github/workflows/docs-publish-mkdocs.yml@v1.9.0

--- a/customizer.sh
+++ b/customizer.sh
@@ -180,6 +180,31 @@ update_library_build_gradle() {
     print_success "Updated library build configuration"
 }
 
+# Update mkdocs.yml to substitute TEMPLATE_* placeholders
+update_mkdocs_config() {
+    print_section "Updating mkdocs.yml"
+
+    local mkdocs_file="mkdocs.yml"
+    if [ ! -f "$mkdocs_file" ]; then
+        print_warning "mkdocs.yml not found — skipping"
+        return 0
+    fi
+
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s|TEMPLATE_LIBRARY_NAME|$LIBRARY_NAME|g" "$mkdocs_file"
+        sed -i '' "s|TEMPLATE_DESCRIPTION|$LIBRARY_NAME - A Kotlin Multiplatform library|g" "$mkdocs_file"
+        sed -i '' "s|TEMPLATE_ORG|$ORGANIZATION|g" "$mkdocs_file"
+        sed -i '' "s|TEMPLATE_REPO|$LIBRARY_NAME_LOWERCASE|g" "$mkdocs_file"
+    else
+        sed -i "s|TEMPLATE_LIBRARY_NAME|$LIBRARY_NAME|g" "$mkdocs_file"
+        sed -i "s|TEMPLATE_DESCRIPTION|$LIBRARY_NAME - A Kotlin Multiplatform library|g" "$mkdocs_file"
+        sed -i "s|TEMPLATE_ORG|$ORGANIZATION|g" "$mkdocs_file"
+        sed -i "s|TEMPLATE_REPO|$LIBRARY_NAME_LOWERCASE|g" "$mkdocs_file"
+    fi
+
+    print_success "Updated mkdocs.yml"
+}
+
 # Update Kotlin source files
 update_kotlin_sources() {
     print_section "Updating Kotlin Source Files"
@@ -391,6 +416,7 @@ main() {
     update_imports
     update_readme
     update_github_workflows
+    update_mkdocs_config
     setup_git_hooks
     cleanup
     print_final_summary

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,35 @@
+# TEMPLATE_LIBRARY_NAME
+
+> TEMPLATE_DESCRIPTION
+
+This is the documentation site for your library. Replace this content with
+your own. The mkdocs site is configured in `mkdocs.yml` at the repo root.
+
+## Quick start
+
+```kotlin
+// Replace this snippet with your library's smallest meaningful API.
+```
+
+## Sections
+
+- **Getting started** — install, first usage, key concepts
+- **Features** — one page per top-level capability
+- **Platform support** — Android, iOS, Desktop, Web matrices
+- **Operations** — performance, security, parity audits
+- **Release** — release process, postmortem template
+
+## Adding pages
+
+1. Drop the markdown file under `docs/<section>/<page>.md`
+2. Register it in `mkdocs.yml` → `nav:`
+3. Push to `development` — the `docs-publish.yml` workflow rebuilds and
+   redeploys the site automatically (see `.github/workflows/docs-publish.yml`)
+
+## Local preview
+
+```bash
+pip install -r docs/requirements.txt
+mkdocs serve
+# open http://127.0.0.1:8000
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material==9.5.49

--- a/docs/stylesheets/mbs-brand.css
+++ b/docs/stylesheets/mbs-brand.css
@@ -1,0 +1,20 @@
+/* MobileByteLabs brand polish for mkdocs-material — minimal overrides on top
+   of the indigo + amber palette declared in mkdocs.yml. Override for your
+   library's own brand after `customizer.sh` runs. */
+
+:root {
+  --md-primary-fg-color: #3949AB; /* indigo 600 */
+  --md-accent-fg-color: #FFC107;  /* amber 500 */
+}
+
+/* Slightly tighter section headings — the default Material theme spacing
+   wastes vertical real estate on technical reference docs. */
+.md-typeset h2 { margin-top: 1.5em; }
+.md-typeset h3 { margin-top: 1.2em; }
+
+/* Subtle inline-code styling so APIs are scannable in prose. */
+.md-typeset code {
+  background-color: rgba(57, 73, 171, 0.08);
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,82 @@
+site_name: TEMPLATE_LIBRARY_NAME
+site_description: TEMPLATE_DESCRIPTION
+site_url: https://TEMPLATE_ORG.github.io/TEMPLATE_REPO/
+repo_url: https://github.com/TEMPLATE_ORG/TEMPLATE_REPO
+repo_name: TEMPLATE_ORG/TEMPLATE_REPO
+edit_uri: edit/development/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+
+extra_css:
+  - stylesheets/mbs-brand.css
+
+# Wiki-only constructs (consumed by sync-docs-to-wiki.yml). Exclude from
+# the mkdocs site since they don't belong in the canonical nav.
+exclude_docs: |
+  _Sidebar.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+
+validation:
+  links:
+    not_found: info
+    absolute_links: ignore
+    unrecognized_links: info
+
+# Minimal starter nav. Extend per your library's sections. Each entry maps
+# to a markdown file under docs/. The headings below mirror the worker-kmp
+# example: Getting started / Features / Platform support / Operations /
+# Release. Drop the ones you don't need.
+nav:
+  - Home: Home.md
+  # - Getting started:
+  #     - Installation: getting-started/installation.md
+  #     - Quick start: getting-started/quick-start.md
+  # - Features:
+  #     - First capability: features/first-capability.md
+  # - Platform support:
+  #     - Android: platform-support/android.md
+  #     - iOS: platform-support/ios.md
+  # - Operations:
+  #     - Performance: operations/performance.md
+  # - Release:
+  #     - Release process: release/release-process.md

--- a/sync-dirs.sh
+++ b/sync-dirs.sh
@@ -36,6 +36,11 @@ SYNC_FILES=(
     "build.gradle.kts"
     "gradle.properties"
 )
+# Note: mkdocs.yml is intentionally NOT sync'd — each consumer customizes
+# site_name / nav / palette after customizer.sh runs. The .github/workflows/
+# docs-publish.yml caller IS auto-sync'd via the SYNC_DIRS '.github' entry,
+# so upstream version-pin bumps (actionhub@v1.9.0 → v1.10.0) propagate
+# automatically.
 
 # Define exclusions for directories and files
 # Format: "path/to/exclude:type"


### PR DESCRIPTION
## Summary
Adds the docs-publish pipeline to the template so every new repo bootstrapped from this template ships with a live mkdocs documentation site out of the box.

## What's new
- `mkdocs.yml` — Material theme, indigo+amber, starter nav with commented templates; uses `TEMPLATE_LIBRARY_NAME` / `TEMPLATE_ORG` / `TEMPLATE_REPO` sentinels
- `docs/Home.md` — minimal placeholder + local-preview instructions
- `docs/requirements.txt` — pinned `mkdocs-material==9.5.49`
- `docs/stylesheets/mbs-brand.css` — brand polish
- `.github/workflows/docs-publish.yml` — 5-line caller → `MobileByteLabs/mbl-actionhub/docs-publish-mkdocs.yml@v1.9.0`

## Customizer wiring
- New `update_mkdocs_config` function rewrites the 4 `TEMPLATE_*` sentinels in `mkdocs.yml`
- Wired into `main()` after `update_github_workflows`

## Sync-dirs hygiene
- `mkdocs.yml` intentionally NOT added to `SYNC_FILES` (consumers customize the nav after `customizer.sh`)
- `.github/workflows/docs-publish.yml` IS auto-sync'd via the existing `SYNC_DIRS '.github'` entry — upstream version-pin bumps propagate to all derived libraries

## Consumer's bootstrap after `customizer.sh`
1. Repo Settings → Pages → Source: switch to "GitHub Actions"
2. Push to `development` — site deploys to `https://<org>.github.io/<repo>/` within ~30s

## Verified locally
- `python3 -m mkdocs build --strict` → built in 0.17s, zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)