### PR TITLE
fix(docs): add docs/index.md so mkdocs root URL serves Home content

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -21,4 +21,4 @@ permissions:
 
 jobs:
   publish:
-    uses: MobileByteLabs/mbl-actionhub/.github/workflows/docs-publish-mkdocs.yml@v1.9.0
+    uses: MobileByteLabs/mbl-actionhub/.github/workflows/docs-publish-mkdocs.yml@v1.9.1

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,35 @@
+# TEMPLATE_LIBRARY_NAME
+
+> TEMPLATE_DESCRIPTION
+
+This is the documentation site for your library. Replace this content with
+your own. The mkdocs site is configured in `mkdocs.yml` at the repo root.
+
+## Quick start
+
+```kotlin
+// Replace this snippet with your library's smallest meaningful API.
+```
+
+## Sections
+
+- **Getting started** — install, first usage, key concepts
+- **Features** — one page per top-level capability
+- **Platform support** — Android, iOS, Desktop, Web matrices
+- **Operations** — performance, security, parity audits
+- **Release** — release process, postmortem template
+
+## Adding pages
+
+1. Drop the markdown file under `docs/<section>/<page>.md`
+2. Register it in `mkdocs.yml` → `nav:`
+3. Push to `development` — the `docs-publish.yml` workflow rebuilds and
+   redeploys the site automatically (see `.github/workflows/docs-publish.yml`)
+
+## Local preview
+
+```bash
+pip install -r docs/requirements.txt
+mkdocs serve
+# open http://127.0.0.1:8000
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,8 +37,12 @@ extra_css:
 
 # Wiki-only constructs (consumed by sync-docs-to-wiki.yml). Exclude from
 # the mkdocs site since they don't belong in the canonical nav.
+# Home.md is wiki's home page (basename-indexed). mkdocs needs index.md
+# for the root URL — same content lives in both files; exclude Home.md
+# here to avoid a redundant /Home/ page in the rendered site.
 exclude_docs: |
   _Sidebar.md
+  Home.md
 
 markdown_extensions:
   - admonition
@@ -67,7 +71,7 @@ validation:
 # example: Getting started / Features / Platform support / Operations /
 # Release. Drop the ones you don't need.
 nav:
-  - Home: Home.md
+  - Home: index.md
   # - Getting started:
   #     - Installation: getting-started/installation.md
   #     - Quick start: getting-started/quick-start.md


### PR DESCRIPTION
## Summary
- Mkdocs needs `docs/index.md` to render `/index.html`; the existing `docs/Home.md` only generated `/Home/`.
- Add `docs/index.md` (identical placeholder content); keep `docs/Home.md` for wiki.
- Exclude `Home.md` from the mkdocs build to avoid a duplicate `/Home/` page.
- Bump caller workflow pin to `@v1.9.1` (configure-pages auto-enablement → zero-touch first run on consumer repos).

Consumers bootstrapped from this template post-merge will get a working `/` URL out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)