### PR TITLE
docs: add docs/DEVELOPMENT.md authoring guide

### DIFF
--- a/docs/DEVELOPMENT-TEMPLATE.md
+++ b/docs/DEVELOPMENT-TEMPLATE.md
@@ -1,165 +1,226 @@
-# Docs authoring guide (template)
+---
+title: Docs guide (template)
+description: Canonical authoring blueprint for KMP library documentation. Sync'd from mbl-library-template-kmp into every consumer repo; do not edit downstream.
+---
 
-The canonical, reusable blueprint for writing the documentation that lives
-under `docs/`. This file is **owned by `mbl-library-template-kmp`** and
-sync'd into every consumer repo via `sync-dirs.sh` (SYNC_FILES). Do not
-edit this file in a consumer repo — your edits will be overwritten on the
-next sync. Instead, override or extend per-project in `docs/DEVELOPMENT.md`
-(see §"Project-specific extensions" at the bottom).
+# Docs guide (template)
 
-Serves two audiences: human contributors (read top to bottom) and AI agents
-(grep for the structured sections — Agent quick reference, Invariants,
-Scaling rubric, Validation commands).
+!!! abstract "What this file is"
+    The canonical, reusable blueprint for writing the documentation that lives
+    under `docs/`. **Owned by [`mbl-library-template-kmp`](https://github.com/MobileByteLabs/mbl-library-template-kmp)**
+    and sync'd into every consumer repo via `sync-dirs.sh` (see `SYNC_FILES`).
+
+    Edits made to this file in a consumer repo **will be overwritten on the
+    next sync**. For library-specific extensions, use the sibling
+    [`DEVELOPMENT.md`](DEVELOPMENT.md).
+
+!!! info "Two audiences"
+    **Humans** read top to bottom for orientation.
+    **AI agents** grep for the four canonical headings — Agent quick
+    reference, Invariants, Scaling rubric, Validation commands — to act
+    deterministically without parsing prose.
+
+---
 
 ## Agent quick reference
 
-Common operations as copy-paste recipes. Each row is the *complete* action;
-follow every step.
+Each row is the **complete** recipe. Follow every step in order.
 
 | Want to… | Recipe |
 |----------|--------|
-| Add a narrative page | (1) Write `docs/<slug>.md` (2) Add `- <Title>: <slug>.md` under the right section in `mkdocs.yml` → `nav:` (3) `git add` both → commit |
-| Add a section | (1) `mkdir docs/<section>` (2) Author `docs/<section>/<first-page>.md` (3) Add `- <Section>:\n  - <Page>: <section>/<first-page>.md` block to `mkdocs.yml` → `nav:` |
-| Add an image / asset | (1) Drop into `docs/images/` (create if needed) (2) Reference as `![Alt](images/<file>)` from any page |
-| Override brand color | Edit `docs/stylesheets/mbs-brand.css` → `--md-primary-fg-color` (header/links) + `--md-accent-fg-color` (highlights, copy button) |
+| Add a narrative page | (1) Author `docs/<slug>.md` (2) Add `- <Title>: <slug>.md` under the right section in `mkdocs.yml` → `nav:` (3) `git add` both → commit |
+| Add a section | (1) `mkdir docs/<section>` (2) Author the first page (3) Add a `- <Section>:\n  - <Page>: <section>/<page>.md` block to `mkdocs.yml` → `nav:` |
+| Add an image/asset | (1) Drop into `docs/images/` (create if needed) (2) Reference as `![Alt](images/<file>)` from any page |
+| Override brand colors | Edit `docs/stylesheets/mbs-brand.css` → `--md-primary-fg-color` (header/links) + `--md-accent-fg-color` (highlights, copy button) |
 | Test build locally | `pip install -r docs/requirements.txt && mkdocs build --strict` |
 | Live preview | `mkdocs serve` → open `http://127.0.0.1:8000` |
-| Upgrade docs pipeline | Bump `@vX.Y.Z` pin in `.github/workflows/docs-publish.yml` → next push redeploys via new version |
+| Upgrade docs pipeline | Bump `@vX.Y.Z` pin in `.github/workflows/docs-publish.yml` |
 | Trigger deploy manually | `gh workflow run docs-publish.yml --ref development` |
-| Investigate `/` 404 | Verify `docs/index.md` exists (mkdocs requires it for the root URL) |
-| Investigate site shows old content | Cmd-Shift-R (CDN); wait 1-2 min; if persistent, check Pages config: `gh api repos/<org>/<repo>/pages` |
-| Edit Home/index content | **Edit both** `docs/Home.md` and `docs/index.md` — they MUST stay in sync (see Invariants below) |
-| Disable Jekyll on Pages site | (Already done — `actions/configure-pages@v5` with `enablement: true` in reusable workflow at `v1.9.1+` handles this) |
+| Investigate `/` 404 | Verify `docs/index.md` exists (mkdocs needs it for the root URL) |
+| Edit Home / index content | Edit **both** `docs/Home.md` and `docs/index.md` — they MUST stay in sync |
+| Disable Jekyll on Pages | Already handled — reusable workflow `v1.9.1+` calls `actions/configure-pages@v5` with `enablement: true` |
+
+---
 
 ## Invariants
 
-When you touch the file in the first column, you MUST also update the
-files in the second column in the same commit (or the next push will break
-something).
+When the file in the first column changes, the files in the second column
+**must** also change in the same commit. Skipping either side breaks the
+contract.
 
 | If you change… | Also update… | Why |
 |----------------|--------------|-----|
-| `docs/Home.md` content | `docs/index.md` (mirror) | Wiki uses Home.md; mkdocs uses index.md. Divergence = surfaces show different content. |
+| `docs/Home.md` content | `docs/index.md` (mirror) | Wiki uses `Home.md`; mkdocs uses `index.md`. Divergence = surfaces show different content. |
 | `docs/index.md` content | `docs/Home.md` (mirror) | Same reason, reversed. |
-| Added a new `docs/<page>.md` (user-facing) | `mkdocs.yml` → `nav:` | Page exists on disk but no nav entry = invisible on site. |
-| New section directory | `mkdocs.yml` → `nav:` (new section block) | Same — directory contents don't appear without nav registration. |
-| Renamed a page | (1) Update all inbound `[link](old.md)` references (2) Optionally add a redirect via `mkdocs-redirects` plugin | Otherwise old URLs 404 and inbound links break. |
-| Deleted a page | (1) Remove from `mkdocs.yml` nav (2) Grep for inbound links + fix or delete them | Strict-mode build fails on dangling nav entries. |
-| Bumped `mkdocs-material` in `docs/requirements.txt` | Run `mkdocs build --strict` locally — Material can introduce theme breaks across minors | CI catches this, but you waste a deploy cycle if you skip local verification. |
-| Bumped caller pin (`@v1.9.1` → `@v1.10.x`) in `.github/workflows/docs-publish.yml` | Verify the new tag actually exists at `MobileByteLabs/mbl-actionhub` | Pinning a non-existent tag fails at workflow-resolution time. |
+| New user-facing page under `docs/` | `mkdocs.yml` → `nav:` (registration) | Page on disk + no nav entry = invisible on site. |
+| New section directory | `mkdocs.yml` → `nav:` (new section block) | Contents don't appear until the section is registered. |
+| Renamed page | (1) Update all inbound `[link](old.md)` references (2) Optionally add a redirect via `mkdocs-redirects` plugin | Old URLs 404 + inbound links break. |
+| Deleted page | (1) Remove from `mkdocs.yml` nav (2) Grep for inbound links + fix or delete | Strict-mode build fails on dangling nav entries. |
+| Bumped `mkdocs-material` in `docs/requirements.txt` | Run `mkdocs build --strict` locally + visually preview | Material can introduce theme breaks across minor versions. |
+| Bumped caller pin (`@v1.9.1` → `@v1.10.x`) in `.github/workflows/docs-publish.yml` | Verify the new tag exists at `MobileByteLabs/mbl-actionhub` | Pinning a non-existent tag fails workflow resolution. |
 
-## Two surfaces, one source
+---
 
-Files in `docs/` feed **two** published surfaces:
+## The dual-surface contract
 
-| Surface | Pipeline | Lands at |
-|---------|----------|----------|
-| **mkdocs site** (canonical) | `.github/workflows/docs-publish.yml` → `mbl-actionhub/docs-publish-mkdocs.yml` | `https://<org>.github.io/<repo>/` |
-| **GitHub Wiki** | `.github/workflows/sync-docs-to-wiki.yml` → `mbl-actionhub-docshub` composite | `https://github.com/<org>/<repo>/wiki/<basename>` |
+Files under `docs/` feed two published surfaces simultaneously. Each
+surface has different conventions — but the **source is the same files**.
 
-Both pipelines trigger on push to `development` whenever `docs/**` or `mkdocs.yml`
-changes. There is no "write once, sync later" step — the merge is the deploy.
+=== "mkdocs site (canonical)"
+
+    **Pipeline:** `.github/workflows/docs-publish.yml` → reusable
+    `mbl-actionhub/docs-publish-mkdocs.yml`
+
+    **Lands at:** `https://<org>.github.io/<repo>/`
+
+    **Triggered:** on push to `development` when `docs/**`, `mkdocs.yml`, or
+    the caller workflow itself changes.
+
+    **Build:** mkdocs-material renders every `.md` in `docs/` (except those
+    in `exclude_docs:`) into static HTML. `actions/deploy-pages` hands the
+    artifact to Pages.
+
+=== "GitHub Wiki"
+
+    **Pipeline:** `.github/workflows/sync-docs-to-wiki.yml` → composite
+    action `mbl-actionhub-docshub`
+
+    **Lands at:** `https://github.com/<org>/<repo>/wiki/<basename>`
+
+    **Triggered:** same paths, same branch.
+
+    **Build:** the composite walks `docs/` and pushes each `.md` to the
+    wiki repo, basename-indexed. Wiki uses `Home.md` as its landing page.
+
+!!! warning "Don't edit on the surfaces — edit the source"
+    The site and wiki are read-only outputs. Always edit `docs/<file>.md`
+    and push to `development`; both surfaces redeploy within ~30 seconds.
+
+---
 
 ## Files with special meaning
 
 | File | Used by | Purpose |
 |------|---------|---------|
-| `index.md` | mkdocs | Root URL of the site (`/`). Required — without it the root returns 404. |
-| `Home.md` | wiki | Wiki's home page. GitHub Wiki indexes by basename; this name is hard-coded. Excluded from the mkdocs build (`exclude_docs:`) to avoid a duplicate `/Home/` page. |
-| `_Sidebar.md` | wiki | Wiki sidebar nav. Excluded from the mkdocs build. |
-| `requirements.txt` | docs-publish workflow | Pinned mkdocs deps — change a version here, not in the workflow. |
-| `stylesheets/mbs-brand.css` | mkdocs | Brand polish. Override colors for your library here. |
+| `docs/index.md` | mkdocs | Root URL of the site (`/`). **Required** — without it the root returns 404. |
+| `docs/Home.md` | wiki | Wiki's home page. GitHub Wiki indexes by basename; this filename is hard-coded. Excluded from the mkdocs build via `exclude_docs:` to avoid a duplicate `/Home/` page. |
+| `docs/_Sidebar.md` | wiki | Wiki sidebar nav. Excluded from the mkdocs build. |
+| `docs/requirements.txt` | docs-publish workflow | Pinned mkdocs deps. Change a version **here**, not in the workflow. |
+| `docs/stylesheets/mbs-brand.css` | mkdocs | Brand polish. Override `--md-primary-fg-color` and `--md-accent-fg-color` here. |
 
-`index.md` and `Home.md` are duplicates by design: mkdocs needs `index.md`,
-wiki needs `Home.md`, and they should always show the same landing content.
-When you edit one, edit the other.
+!!! tip "Home.md and index.md are duplicates by design"
+    mkdocs needs `index.md`, wiki needs `Home.md`, and they should always
+    show the same landing content. **Edit one → edit the other in the same commit.**
 
-## Adding a new page (3-step)
+---
 
-1. **Write the markdown** under the appropriate section directory
-   (`docs/<section>/<page-slug>.md`). Use kebab-case for filenames.
-2. **Register it in `mkdocs.yml`** under `nav:`. The section heading you put it
-   under is what appears in the site's tab bar.
-3. **Push to `development`** — the docs-publish workflow rebuilds and
-   redeploys the site within ~30 seconds.
+## Adding a new page
 
-Wiki picks up the new file automatically (no nav registration needed —
-wiki uses `_Sidebar.md` for nav).
+```bash
+# 1. Write the page (kebab-case filename)
+echo "# My new page" > docs/<section>/<my-new-page>.md
 
-## Section conventions
+# 2. Edit mkdocs.yml → nav: add the entry under the right section
+#    - <Section>:
+#        - <Title>: <section>/<my-new-page>.md
 
-The starter `mkdocs.yml` declares these sections. Use them or replace them,
-but keep the structure shallow (≤2 levels of nesting):
+# 3. Verify locally
+mkdocs serve  # browse to the new page
 
-| Section | What goes here |
-|---------|----------------|
-| **Home** | Library overview, badges, "why this exists" — same content as `index.md`/`Home.md`. |
-| **Getting started** | Install, first usage, key concepts, migration guides. Each page should be runnable end-to-end. |
-| **Features** | One page per top-level capability. Title each page as a noun phrase ("Foreground tasks"), not a verb ("How to run foreground tasks"). |
-| **Platform support** | Per-platform pages + matrix tables. Capture quirks, capabilities, and not-yet-supported APIs. |
-| **Operations** | Performance, security, audits, threat models — anything ops-oriented for production deployers. |
-| **Release** | Release process, postmortem template, deprecation policy. |
+# 4. Commit + push
+git add docs/<section>/<my-new-page>.md mkdocs.yml
+git commit -m "docs: add <my-new-page>"
+git push origin development
+```
+
+The docs-publish workflow rebuilds and redeploys within ~30 seconds.
+The wiki sync picks up the new file automatically — no nav registration
+needed there (wiki uses `_Sidebar.md` for nav).
+
+---
 
 ## Style guide
 
 ### Code blocks
 
-Always declare the language. mkdocs-material renders Kotlin, Swift, Bash, YAML,
-JSON, and TOML out of the box. Never leave a code block unlabeled.
+Always declare the language. mkdocs-material renders Kotlin, Swift, Bash,
+YAML, JSON, and TOML out of the box.
 
-````markdown
 ```kotlin
 val worker = MyWorker()
 ```
-````
 
-Inline `code` for symbols + flag names. Use `**bold**` for first-mention
-emphasis of a concept (sparingly).
+Inline `code` for symbols and flag names. Use `**bold**` sparingly for
+first-mention emphasis of a concept.
 
 ### Admonitions
 
-Use admonitions (`!!! note`, `!!! warning`, `!!! tip`) for callouts that break
-the flow but are important. Don't use them for body text.
+Use `!!! note`, `!!! warning`, `!!! tip`, `!!! example`, `!!! info`,
+`!!! danger`, `!!! success`, `!!! abstract` for callouts that break the
+prose flow but are important.
+
+!!! example "Admonition syntax"
+    ```markdown
+    !!! warning "iOS background time is finite"
+        BGTaskScheduler grants ~30s of execution. Long work needs
+        `URLSession.uploadTask` instead.
+    ```
+
+For collapsible content, use `???` instead of `!!!`:
 
 ```markdown
-!!! warning "iOS background time is finite"
-    BGTaskScheduler grants ~30s of execution. Long work needs
-    `URLSession.uploadTask` instead.
+??? note "Click to expand"
+    Hidden until clicked. Useful for long examples or troubleshooting.
 ```
+
+### Tabbed content
+
+Use `pymdownx.tabbed` for multi-flavor content (per-platform examples,
+multiple language equivalents):
+
+````markdown
+=== "Android"
+    ```kotlin
+    // Android-specific
+    ```
+
+=== "iOS"
+    ```kotlin
+    // iOS-specific
+    ```
+````
 
 ### Tables
 
-Use tables for any comparison with ≥3 dimensions (platforms × features,
-versions × behaviors, options × tradeoffs). Inline lists are fine for
-≤2 dimensions.
+Use tables for comparisons with ≥3 dimensions (platforms × features,
+versions × behaviors). Inline bullet lists are fine for ≤2 dimensions.
 
 ### Links
 
-- **Internal** (within the docs/ tree): use relative paths
-  (`[Quick start](getting-started/quick-start.md)`). mkdocs validates these on
-  build; broken links surface as INFO-level warnings.
+- **Internal** (within `docs/`): relative paths
+  (`[Quick start](getting-started/quick-start.md)`). mkdocs validates these
+  on build; broken links surface as INFO-level warnings.
 - **External**: full URLs.
-- **Cross-repo source** (`workspaces/mbs/...`): the warning is INFO-level and
-  expected — the link works on GitHub source view but not on the docs site.
-- **API reference**: link to the published Dokka HTML (bundled inside each
-  module's `-javadoc.jar`) or to Maven Central.
+- **Cross-repo source** (e.g. `workspaces/mbs/...`): downgraded to INFO via
+  `validation.links.not_found: info` in `mkdocs.yml`. Expected.
 
 ### Per-platform caveats
 
-When a feature behaves differently across platforms, structure as:
+When behavior varies across platforms, use this pattern:
 
 ```markdown
-## Per-platform notes
-
-- **Android:** ... 
-- **iOS:** ...
-- **JVM Desktop:** ...
-- **JS / wasmJs:** ...
+- **Android:** auto-init via ContentProvider; no manual `init()` needed.
+- **iOS:** call from `applicationDidFinishLaunching`.
+- **JVM Desktop:** prints to `System.out`; ANSI color enabled if TTY.
+- **JS / wasmJs:** requires a user gesture on first invocation.
 ```
 
-This pattern is grep-friendly and reads consistently across the site.
+The bullet-with-bold-platform-name pattern is grep-friendly and reads
+consistently across the site.
 
-## Test locally before pushing
+---
+
+## Local preview
 
 ```bash
 pip install -r docs/requirements.txt
@@ -167,52 +228,36 @@ mkdocs serve
 # open http://127.0.0.1:8000
 ```
 
-`mkdocs build --strict` is what CI runs. If strict fails locally, it'll fail
-in CI. Most common cause: a nav entry references a file that doesn't exist,
-or a relative link points outside `docs/`.
+!!! tip "Strict mode mirrors CI"
+    `mkdocs build --strict` is what the CI workflow runs. If strict
+    fails locally, it'll fail in CI. Most common cause: a nav entry
+    references a file that doesn't exist, or a relative link points
+    outside `docs/`.
 
-## What NOT to do
+---
 
-- **Don't hand-author files under `site/`** — that directory is the mkdocs
-  build output, regenerated on every deploy.
-- **Don't commit `.cache/` or generated assets** — `.gitignore` already
-  excludes them; if you see one in `git status`, fix the ignore instead of
-  staging it.
-- **Don't edit the workflow** to change build behavior. The build logic
-  lives in `mbl-actionhub/docs-publish-mkdocs.yml`. Bump the `@vX.Y.Z` pin
-  in `.github/workflows/docs-publish.yml` to upgrade.
-- **Don't add a `docs/CNAME` file** to set a custom domain — configure it
-  via the repo's Pages settings (UI or `gh api ... -f cname=...`).
-- **Don't author Liquid templating** in markdown. The mkdocs site doesn't
-  process Liquid, but if Pages is ever misconfigured back to legacy Jekyll
-  it will fail to render those files. (The `mkdocs-macros-plugin` —
-  enabled in some consumer libraries — will also reject stray Liquid-style
-  brace syntax with "Macro Syntax Error" at build time.)
+## Scaling rubric
 
-## Adding a new section to the nav
+The starter `mkdocs.yml` ships with a 5-section nav. That's intentionally
+optimistic — most early-stage libraries shouldn't pre-create all sections.
 
-Edit `mkdocs.yml` → `nav:` block. Each entry is `Section Title:` followed by
-either a single `page.md` or a nested list of pages. Keep section titles
-≤3 words; the navigation tab bar truncates long titles.
+**Start flat. Split a section only when it has ≥ 4 pages.**
 
-```yaml
-nav:
-  - Home: index.md
-  - Getting started:
-      - Installation: getting-started/installation.md
-      - Quick start: getting-started/quick-start.md
-  - New section:
-      - First page: new-section/first-page.md
-```
+| Library shape | docs/ structure |
+|---------------|-----------------|
+| **1 module, < 5 pages** | Flat: `index.md`, `Home.md`, `getting-started.md`, `api.md`. No subdirs. `mkdocs.yml` nav = 4 entries. |
+| **1-2 modules, 5-15 pages** | Add `getting-started/` + `features/` subdirs. Keep operations + release inline as single pages until each grows to ≥ 4 pages. |
+| **2-5 modules, 15-30 pages** | Adopt the full starter nav (6 sections). Each section has its own subdir. Add a `platform-support/` matrix page. |
+| **5+ modules** | Introduce `docs/modules/<module>.md` per-module landing pages. Use `mkdocs-include-markdown-plugin` to mirror each module's source-tree README. Add a Modules section to nav. |
+| **Heavy how-to content** (≥ 10 task-oriented pages) | Introduce a `docs/cookbook/<topic>/<recipe>.md` structure. One page per task, named as a user question ("How do I X?"). See [KmpToolkit](https://github.com/MobileByteLabs/KmpToolkit) for the live pattern. |
+| **Heavy API reference** | Don't render API ref in mkdocs. Bundle Dokka HTML inside `-javadoc.jar` (per-module `dokkaGeneratePublicationHtml` + `vanniktech.mavenPublish.JavadocJar.Dokka` config) and link to Maven Central from the mkdocs site. |
 
-## Updating the brand
+!!! warning "Anti-pattern: pre-structuring for hypothetical growth"
+    Empty sections (headings with one stub page) look unprofessional and add
+    nav clutter. Three nav entries with content > seven nav entries
+    half-filled.
 
-`docs/stylesheets/mbs-brand.css` declares primary + accent colors via
-`--md-primary-fg-color` and `--md-accent-fg-color`. Change these to match
-your library's brand. Tweak typography spacing in the same file — keep
-changes small; mkdocs-material's defaults are well-considered.
-
-For the palette toggle (light/dark mode), edit `mkdocs.yml` → `theme.palette`.
+---
 
 ## When the site breaks
 
@@ -221,112 +266,126 @@ For the palette toggle (light/dark mode), edit `mkdocs.yml` → `theme.palette`.
 | `/` returns 404 | `docs/index.md` missing | Add it (duplicate of `Home.md`). |
 | Build fails: "unrecognized relative link" | A `*.md` link points outside `docs/` | Either fix the link or accept it (it'll surface as INFO, not error). |
 | Build fails: "nav references file that doesn't exist" | `mkdocs.yml` nav has a stale entry | Remove the entry or create the file. |
-| Pages deploy succeeds but site shows old content | CDN cache | Hard refresh (Cmd-Shift-R). Usually clears within 1-2 minutes. |
+| Pages deploy succeeds but site shows old content | CDN cache | Hard refresh (Cmd-Shift-R). Usually clears within 1-2 min. |
 | `configure-pages` errors with "Get Pages site failed" | Repo's Pages source not set to "GitHub Actions" | Bump caller workflow pin to `v1.9.1+` (auto-enables) OR flip Settings → Pages → Source manually. |
 
-## Wiki-specific notes
+---
 
-- Wiki sync requires the wiki to be initialized (Settings → Features → Wikis
-  → enabled, then create any first page via the Wiki UI). Without this, the
-  composite errors with "Repository not found".
-- `_Sidebar.md` in `docs/` becomes the wiki's left nav. If you want wiki
-  auto-sidebar generation, set `sidebar-mode: auto` in the workflow inputs
-  (the default).
-- Wiki indexes by basename — two files named the same in different subdirs
-  collide. The docshub composite resolves by subdir-prefixing the slug, but
-  it's cleaner to avoid the collision in the first place.
+## Pipeline architecture
 
-## Pipeline architecture (one-paragraph version)
+??? info "How the docs-publish workflow actually works"
+    The build + deploy logic lives **once** in
+    [`mbl-actionhub/docs-publish-mkdocs.yml`](https://github.com/MobileByteLabs/mbl-actionhub/blob/main/.github/workflows/docs-publish-mkdocs.yml).
 
-The build + deploy logic lives **once** in
-[`mbl-actionhub/docs-publish-mkdocs.yml`](https://github.com/MobileByteLabs/mbl-actionhub/blob/main/.github/workflows/docs-publish-mkdocs.yml).
-This repo's `.github/workflows/docs-publish.yml` is a 5-line caller that
-pins to a specific version (`@v1.9.1` at time of writing). Upgrades happen
-in one place; consumers bump the pin to opt in.
+    This repo's `.github/workflows/docs-publish.yml` is a 5-line caller
+    that pins a specific version (`@v1.9.1+`). Pipeline steps:
 
-## Scaling rubric
+    1. `actions/checkout@v4`
+    2. `actions/setup-python@v5` (with `cache: pip` + `cache-dependency-path: docs/requirements.txt`)
+    3. `pip install -r docs/requirements.txt`
+    4. `mkdocs build --strict` → produces `site/`
+    5. `touch ./site/.nojekyll` (belt-and-suspenders Jekyll disable)
+    6. `actions/configure-pages@v5` with `enablement: true` (auto-enables Pages on first run)
+    7. `actions/upload-pages-artifact@v3`
+    8. `actions/deploy-pages@v4` (separate job, environment-gated)
 
-The starter `mkdocs.yml` ships with a 5-section nav (Home / Getting started
-/ Features / Platform support / Operations / Release). That's intentionally
-optimistic — most early-stage libraries shouldn't pre-create all of those.
+    Upgrades happen in one place; consumers bump the pin to opt in.
 
-Start flat. Split a section only when it has **≥ 4 pages**. Use this rubric
-to choose the right structure for your library's current size:
+---
 
-| Library shape | docs/ structure |
-|---------------|-----------------|
-| **1 module, < 5 pages** | Flat: `index.md`, `Home.md`, `getting-started.md`, `api.md`. No subdirs. `mkdocs.yml` nav = 4 entries. |
-| **1-2 modules, 5-15 pages** | Add `getting-started/` + `features/` subdirs. Keep operations + release inline as single pages until each grows to ≥ 4 pages. |
-| **2-5 modules, 15-30 pages** | Adopt the full starter nav (6 sections). Each section has its own subdir. Add a `platform-support/` matrix page. |
-| **5+ modules** | Introduce `docs/modules/<module>.md` per-module landing pages. Use `mkdocs-include-markdown-plugin` to mirror each module's source-tree README. Add a Modules section to nav. |
-| **Heavy how-to content** (≥ 10 task-oriented pages) | Introduce a `docs/cookbook/<topic>/<recipe>.md` structure. One page per task, named as a user question ("How do I X?"). See KmpToolkit for the live pattern. |
-| **Heavy API reference** | Don't try to render API ref in mkdocs. Bundle Dokka HTML inside `-javadoc.jar` (per-module `dokkaGeneratePublicationHtml` + `vanniktech.mavenPublish.JavadocJar.Dokka` config) and link to Maven Central from the mkdocs site. |
+## Wiki notes
 
-Anti-pattern: pre-structuring for hypothetical growth. Empty sections
-(headings with one stub page) look unprofessional and add nav clutter.
-Three nav entries with content > seven nav entries half-filled.
+??? note "Wiki sync specifics"
+    - Wiki sync requires the wiki to be initialized:
+      Settings → Features → Wikis → enabled, then create any first
+      page via the Wiki UI. Without this, the composite errors with
+      "Repository not found".
+    - `_Sidebar.md` in `docs/` becomes the wiki's left nav. Set
+      `sidebar-mode: auto` in the workflow inputs (the default) to
+      auto-generate it if absent.
+    - Wiki indexes by basename — two files named the same in different
+      subdirs collide. The docshub composite resolves by subdir-prefixing
+      the slug, but it's cleaner to avoid the collision in the first
+      place.
+
+---
 
 ## Validation commands
 
-Exact CLI snippets agents can run without modification.
+??? example "Full CLI reference"
+    Exact snippets agents can run without modification.
 
-```bash
-# Strict build (what CI runs)
-pip install -r docs/requirements.txt
-mkdocs build --strict
+    ```bash
+    # Strict build (what CI runs)
+    pip install -r docs/requirements.txt
+    mkdocs build --strict
 
-# Live preview
-mkdocs serve  # → http://127.0.0.1:8000
+    # Live preview
+    mkdocs serve  # → http://127.0.0.1:8000
 
-# List every WARNING / ERROR from a strict build (filter out INFO noise)
-mkdocs build --strict 2>&1 | grep -E "^(WARNING|ERROR)"
+    # Show only WARNING/ERROR from strict build (filter INFO noise)
+    mkdocs build --strict 2>&1 | grep -E "^(WARNING|ERROR)"
 
-# Count pages
-find docs -name "*.md" -not -path "*/stylesheets/*" | wc -l
+    # Count pages
+    find docs -name "*.md" -not -path "*/stylesheets/*" | wc -l
 
-# Confirm Home.md and index.md are in sync (zero diff = OK)
-diff docs/Home.md docs/index.md && echo "OK: in sync"
+    # Confirm Home.md and index.md are in sync (zero diff = OK)
+    diff docs/Home.md docs/index.md && echo "OK: in sync"
 
-# Show current caller pin
-grep "docs-publish-mkdocs.yml@" .github/workflows/docs-publish.yml
+    # Show current caller pin
+    grep "docs-publish-mkdocs.yml@" .github/workflows/docs-publish.yml
 
-# Trigger deploy manually (workflow_dispatch)
-gh workflow run docs-publish.yml --ref development
+    # Trigger deploy manually (workflow_dispatch)
+    gh workflow run docs-publish.yml --ref development
 
-# Inspect Pages config (build_type should be "workflow")
-gh api repos/<org>/<repo>/pages --jq '"build_type: \(.build_type)\nstatus: \(.status)"'
+    # Inspect Pages config (build_type should be "workflow")
+    gh api repos/<org>/<repo>/pages --jq '"build_type: \(.build_type)\nstatus: \(.status)"'
 
-# Watch the most recent deploy run to completion
-gh run watch $(gh run list --workflow=docs-publish.yml --limit 1 --json databaseId -q '.[0].databaseId') --exit-status
+    # Watch the most recent deploy to completion
+    gh run watch $(gh run list --workflow=docs-publish.yml --limit 1 --json databaseId -q '.[0].databaseId') --exit-status
 
-# Verify the site is live (after CDN propagation)
-curl -sI https://<org>.github.io/<repo>/ | head -1   # expect HTTP/2 200
-```
+    # Verify the site is live (after CDN propagation)
+    curl -sI https://<org>.github.io/<repo>/ | head -1   # expect HTTP/2 200
+    ```
 
-When any of these fail, the corresponding fix is in the troubleshooting
-table above ("When the site breaks").
+    When any of these fail, the corresponding fix is in the "When the
+    site breaks" table above.
+
+---
+
+## What NOT to do
+
+!!! danger "Common footguns"
+    - **Don't hand-author files under `site/`** — that directory is the
+      mkdocs build output, regenerated on every deploy.
+    - **Don't commit `.cache/` or generated assets** — `.gitignore` excludes
+      them. If you see one in `git status`, fix the ignore instead of
+      staging it.
+    - **Don't edit the workflow** to change build behavior. The logic lives
+      in `mbl-actionhub/docs-publish-mkdocs.yml`. Bump the `@vX.Y.Z` pin in
+      `.github/workflows/docs-publish.yml` to upgrade.
+    - **Don't add a `docs/CNAME` file** to set a custom domain — configure
+      it via the repo's Pages settings (UI or `gh api ... -f cname=...`).
+    - **Don't author Liquid templating** in markdown. The mkdocs site
+      doesn't process it, but `mkdocs-macros-plugin` (enabled in some
+      consumer libraries) rejects stray Liquid-style brace syntax with
+      "Macro Syntax Error" at build time, and legacy Jekyll Pages would
+      also fail to render those files.
+
+---
 
 ## Project-specific extensions
 
-This file (`docs/DEVELOPMENT-TEMPLATE.md`) is generic and sync'd from the
-template — your library cannot edit it (next sync would clobber the change).
+This file is generic. When your library has conventions that don't fit the
+generic blueprint — a cookbook-recipe enforcement schema, a multi-module
+modules/ index, custom validators — author them in the sibling
+[`docs/DEVELOPMENT.md`](DEVELOPMENT.md).
 
-When your library has conventions that don't fit the generic blueprint —
-a cookbook-recipe enforcement schema, a multi-module modules/ index, a
-release-cadence rubric, custom validators — author them in a sibling file
-named **`docs/DEVELOPMENT.md`**. That file:
-
-- Lives in your library only (NOT sync'd from the template)
-- Layers on top of this generic guide rather than replacing it
-- Should be linked from your library's `docs/DEVELOPMENT.md` to this one
-  as the "see also: generic guide"
-
-Examples of content that belongs in the per-project `DEVELOPMENT.md`, not here:
-
-- Cookbook recipe enforcement (line caps, mandatory code-block languages,
-  required frontmatter fields like `reviewed_by`)
-- Per-module page conventions (README-embed vs placeholder duality)
-- Legacy directory migration tasks
-- Library-specific validation commands (e.g. "every `cmp-*` module has a
-  matching `docs/modules/` page")
-- Custom mkdocs plugins or macros
+| Belongs in `DEVELOPMENT-TEMPLATE.md` (this file) | Belongs in `DEVELOPMENT.md` (per-project) |
+|---|---|
+| How to add a page / section / image | Cookbook recipe enforcement (line caps, required langs, frontmatter fields) |
+| Style guide (code blocks, admonitions, tables, links) | Per-module page conventions (README-embed flavor vs placeholder) |
+| Local preview command | Library-specific validators ("every `cmp-*` module has a `docs/modules/` page") |
+| Pipeline architecture | Legacy directory migration plan |
+| Generic agent recipes / invariants / scaling | Library-specific recipes / invariants / scaling cues |
+| `Home.md` ↔ `index.md` dual-surface rule | Custom mkdocs plugins or macros |

--- a/docs/DEVELOPMENT-TEMPLATE.md
+++ b/docs/DEVELOPMENT-TEMPLATE.md
@@ -183,9 +183,11 @@ or a relative link points outside `docs/`.
   in `.github/workflows/docs-publish.yml` to upgrade.
 - **Don't add a `docs/CNAME` file** to set a custom domain — configure it
   via the repo's Pages settings (UI or `gh api ... -f cname=...`).
-- **Don't author Liquid `{% ... %}` syntax** in markdown. The mkdocs site
-  doesn't process Liquid, but if Pages is ever misconfigured back to legacy
-  Jekyll it will fail to render those files.
+- **Don't author Liquid templating** in markdown. The mkdocs site doesn't
+  process Liquid, but if Pages is ever misconfigured back to legacy Jekyll
+  it will fail to render those files. (The `mkdocs-macros-plugin` —
+  enabled in some consumer libraries — will also reject stray Liquid-style
+  brace syntax with "Macro Syntax Error" at build time.)
 
 ## Adding a new section to the nav
 

--- a/docs/DEVELOPMENT-TEMPLATE.md
+++ b/docs/DEVELOPMENT-TEMPLATE.md
@@ -1,0 +1,330 @@
+# Docs authoring guide (template)
+
+The canonical, reusable blueprint for writing the documentation that lives
+under `docs/`. This file is **owned by `mbl-library-template-kmp`** and
+sync'd into every consumer repo via `sync-dirs.sh` (SYNC_FILES). Do not
+edit this file in a consumer repo — your edits will be overwritten on the
+next sync. Instead, override or extend per-project in `docs/DEVELOPMENT.md`
+(see §"Project-specific extensions" at the bottom).
+
+Serves two audiences: human contributors (read top to bottom) and AI agents
+(grep for the structured sections — Agent quick reference, Invariants,
+Scaling rubric, Validation commands).
+
+## Agent quick reference
+
+Common operations as copy-paste recipes. Each row is the *complete* action;
+follow every step.
+
+| Want to… | Recipe |
+|----------|--------|
+| Add a narrative page | (1) Write `docs/<slug>.md` (2) Add `- <Title>: <slug>.md` under the right section in `mkdocs.yml` → `nav:` (3) `git add` both → commit |
+| Add a section | (1) `mkdir docs/<section>` (2) Author `docs/<section>/<first-page>.md` (3) Add `- <Section>:\n  - <Page>: <section>/<first-page>.md` block to `mkdocs.yml` → `nav:` |
+| Add an image / asset | (1) Drop into `docs/images/` (create if needed) (2) Reference as `![Alt](images/<file>)` from any page |
+| Override brand color | Edit `docs/stylesheets/mbs-brand.css` → `--md-primary-fg-color` (header/links) + `--md-accent-fg-color` (highlights, copy button) |
+| Test build locally | `pip install -r docs/requirements.txt && mkdocs build --strict` |
+| Live preview | `mkdocs serve` → open `http://127.0.0.1:8000` |
+| Upgrade docs pipeline | Bump `@vX.Y.Z` pin in `.github/workflows/docs-publish.yml` → next push redeploys via new version |
+| Trigger deploy manually | `gh workflow run docs-publish.yml --ref development` |
+| Investigate `/` 404 | Verify `docs/index.md` exists (mkdocs requires it for the root URL) |
+| Investigate site shows old content | Cmd-Shift-R (CDN); wait 1-2 min; if persistent, check Pages config: `gh api repos/<org>/<repo>/pages` |
+| Edit Home/index content | **Edit both** `docs/Home.md` and `docs/index.md` — they MUST stay in sync (see Invariants below) |
+| Disable Jekyll on Pages site | (Already done — `actions/configure-pages@v5` with `enablement: true` in reusable workflow at `v1.9.1+` handles this) |
+
+## Invariants
+
+When you touch the file in the first column, you MUST also update the
+files in the second column in the same commit (or the next push will break
+something).
+
+| If you change… | Also update… | Why |
+|----------------|--------------|-----|
+| `docs/Home.md` content | `docs/index.md` (mirror) | Wiki uses Home.md; mkdocs uses index.md. Divergence = surfaces show different content. |
+| `docs/index.md` content | `docs/Home.md` (mirror) | Same reason, reversed. |
+| Added a new `docs/<page>.md` (user-facing) | `mkdocs.yml` → `nav:` | Page exists on disk but no nav entry = invisible on site. |
+| New section directory | `mkdocs.yml` → `nav:` (new section block) | Same — directory contents don't appear without nav registration. |
+| Renamed a page | (1) Update all inbound `[link](old.md)` references (2) Optionally add a redirect via `mkdocs-redirects` plugin | Otherwise old URLs 404 and inbound links break. |
+| Deleted a page | (1) Remove from `mkdocs.yml` nav (2) Grep for inbound links + fix or delete them | Strict-mode build fails on dangling nav entries. |
+| Bumped `mkdocs-material` in `docs/requirements.txt` | Run `mkdocs build --strict` locally — Material can introduce theme breaks across minors | CI catches this, but you waste a deploy cycle if you skip local verification. |
+| Bumped caller pin (`@v1.9.1` → `@v1.10.x`) in `.github/workflows/docs-publish.yml` | Verify the new tag actually exists at `MobileByteLabs/mbl-actionhub` | Pinning a non-existent tag fails at workflow-resolution time. |
+
+## Two surfaces, one source
+
+Files in `docs/` feed **two** published surfaces:
+
+| Surface | Pipeline | Lands at |
+|---------|----------|----------|
+| **mkdocs site** (canonical) | `.github/workflows/docs-publish.yml` → `mbl-actionhub/docs-publish-mkdocs.yml` | `https://<org>.github.io/<repo>/` |
+| **GitHub Wiki** | `.github/workflows/sync-docs-to-wiki.yml` → `mbl-actionhub-docshub` composite | `https://github.com/<org>/<repo>/wiki/<basename>` |
+
+Both pipelines trigger on push to `development` whenever `docs/**` or `mkdocs.yml`
+changes. There is no "write once, sync later" step — the merge is the deploy.
+
+## Files with special meaning
+
+| File | Used by | Purpose |
+|------|---------|---------|
+| `index.md` | mkdocs | Root URL of the site (`/`). Required — without it the root returns 404. |
+| `Home.md` | wiki | Wiki's home page. GitHub Wiki indexes by basename; this name is hard-coded. Excluded from the mkdocs build (`exclude_docs:`) to avoid a duplicate `/Home/` page. |
+| `_Sidebar.md` | wiki | Wiki sidebar nav. Excluded from the mkdocs build. |
+| `requirements.txt` | docs-publish workflow | Pinned mkdocs deps — change a version here, not in the workflow. |
+| `stylesheets/mbs-brand.css` | mkdocs | Brand polish. Override colors for your library here. |
+
+`index.md` and `Home.md` are duplicates by design: mkdocs needs `index.md`,
+wiki needs `Home.md`, and they should always show the same landing content.
+When you edit one, edit the other.
+
+## Adding a new page (3-step)
+
+1. **Write the markdown** under the appropriate section directory
+   (`docs/<section>/<page-slug>.md`). Use kebab-case for filenames.
+2. **Register it in `mkdocs.yml`** under `nav:`. The section heading you put it
+   under is what appears in the site's tab bar.
+3. **Push to `development`** — the docs-publish workflow rebuilds and
+   redeploys the site within ~30 seconds.
+
+Wiki picks up the new file automatically (no nav registration needed —
+wiki uses `_Sidebar.md` for nav).
+
+## Section conventions
+
+The starter `mkdocs.yml` declares these sections. Use them or replace them,
+but keep the structure shallow (≤2 levels of nesting):
+
+| Section | What goes here |
+|---------|----------------|
+| **Home** | Library overview, badges, "why this exists" — same content as `index.md`/`Home.md`. |
+| **Getting started** | Install, first usage, key concepts, migration guides. Each page should be runnable end-to-end. |
+| **Features** | One page per top-level capability. Title each page as a noun phrase ("Foreground tasks"), not a verb ("How to run foreground tasks"). |
+| **Platform support** | Per-platform pages + matrix tables. Capture quirks, capabilities, and not-yet-supported APIs. |
+| **Operations** | Performance, security, audits, threat models — anything ops-oriented for production deployers. |
+| **Release** | Release process, postmortem template, deprecation policy. |
+
+## Style guide
+
+### Code blocks
+
+Always declare the language. mkdocs-material renders Kotlin, Swift, Bash, YAML,
+JSON, and TOML out of the box. Never leave a code block unlabeled.
+
+````markdown
+```kotlin
+val worker = MyWorker()
+```
+````
+
+Inline `code` for symbols + flag names. Use `**bold**` for first-mention
+emphasis of a concept (sparingly).
+
+### Admonitions
+
+Use admonitions (`!!! note`, `!!! warning`, `!!! tip`) for callouts that break
+the flow but are important. Don't use them for body text.
+
+```markdown
+!!! warning "iOS background time is finite"
+    BGTaskScheduler grants ~30s of execution. Long work needs
+    `URLSession.uploadTask` instead.
+```
+
+### Tables
+
+Use tables for any comparison with ≥3 dimensions (platforms × features,
+versions × behaviors, options × tradeoffs). Inline lists are fine for
+≤2 dimensions.
+
+### Links
+
+- **Internal** (within the docs/ tree): use relative paths
+  (`[Quick start](getting-started/quick-start.md)`). mkdocs validates these on
+  build; broken links surface as INFO-level warnings.
+- **External**: full URLs.
+- **Cross-repo source** (`workspaces/mbs/...`): the warning is INFO-level and
+  expected — the link works on GitHub source view but not on the docs site.
+- **API reference**: link to the published Dokka HTML (bundled inside each
+  module's `-javadoc.jar`) or to Maven Central.
+
+### Per-platform caveats
+
+When a feature behaves differently across platforms, structure as:
+
+```markdown
+## Per-platform notes
+
+- **Android:** ... 
+- **iOS:** ...
+- **JVM Desktop:** ...
+- **JS / wasmJs:** ...
+```
+
+This pattern is grep-friendly and reads consistently across the site.
+
+## Test locally before pushing
+
+```bash
+pip install -r docs/requirements.txt
+mkdocs serve
+# open http://127.0.0.1:8000
+```
+
+`mkdocs build --strict` is what CI runs. If strict fails locally, it'll fail
+in CI. Most common cause: a nav entry references a file that doesn't exist,
+or a relative link points outside `docs/`.
+
+## What NOT to do
+
+- **Don't hand-author files under `site/`** — that directory is the mkdocs
+  build output, regenerated on every deploy.
+- **Don't commit `.cache/` or generated assets** — `.gitignore` already
+  excludes them; if you see one in `git status`, fix the ignore instead of
+  staging it.
+- **Don't edit the workflow** to change build behavior. The build logic
+  lives in `mbl-actionhub/docs-publish-mkdocs.yml`. Bump the `@vX.Y.Z` pin
+  in `.github/workflows/docs-publish.yml` to upgrade.
+- **Don't add a `docs/CNAME` file** to set a custom domain — configure it
+  via the repo's Pages settings (UI or `gh api ... -f cname=...`).
+- **Don't author Liquid `{% ... %}` syntax** in markdown. The mkdocs site
+  doesn't process Liquid, but if Pages is ever misconfigured back to legacy
+  Jekyll it will fail to render those files.
+
+## Adding a new section to the nav
+
+Edit `mkdocs.yml` → `nav:` block. Each entry is `Section Title:` followed by
+either a single `page.md` or a nested list of pages. Keep section titles
+≤3 words; the navigation tab bar truncates long titles.
+
+```yaml
+nav:
+  - Home: index.md
+  - Getting started:
+      - Installation: getting-started/installation.md
+      - Quick start: getting-started/quick-start.md
+  - New section:
+      - First page: new-section/first-page.md
+```
+
+## Updating the brand
+
+`docs/stylesheets/mbs-brand.css` declares primary + accent colors via
+`--md-primary-fg-color` and `--md-accent-fg-color`. Change these to match
+your library's brand. Tweak typography spacing in the same file — keep
+changes small; mkdocs-material's defaults are well-considered.
+
+For the palette toggle (light/dark mode), edit `mkdocs.yml` → `theme.palette`.
+
+## When the site breaks
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `/` returns 404 | `docs/index.md` missing | Add it (duplicate of `Home.md`). |
+| Build fails: "unrecognized relative link" | A `*.md` link points outside `docs/` | Either fix the link or accept it (it'll surface as INFO, not error). |
+| Build fails: "nav references file that doesn't exist" | `mkdocs.yml` nav has a stale entry | Remove the entry or create the file. |
+| Pages deploy succeeds but site shows old content | CDN cache | Hard refresh (Cmd-Shift-R). Usually clears within 1-2 minutes. |
+| `configure-pages` errors with "Get Pages site failed" | Repo's Pages source not set to "GitHub Actions" | Bump caller workflow pin to `v1.9.1+` (auto-enables) OR flip Settings → Pages → Source manually. |
+
+## Wiki-specific notes
+
+- Wiki sync requires the wiki to be initialized (Settings → Features → Wikis
+  → enabled, then create any first page via the Wiki UI). Without this, the
+  composite errors with "Repository not found".
+- `_Sidebar.md` in `docs/` becomes the wiki's left nav. If you want wiki
+  auto-sidebar generation, set `sidebar-mode: auto` in the workflow inputs
+  (the default).
+- Wiki indexes by basename — two files named the same in different subdirs
+  collide. The docshub composite resolves by subdir-prefixing the slug, but
+  it's cleaner to avoid the collision in the first place.
+
+## Pipeline architecture (one-paragraph version)
+
+The build + deploy logic lives **once** in
+[`mbl-actionhub/docs-publish-mkdocs.yml`](https://github.com/MobileByteLabs/mbl-actionhub/blob/main/.github/workflows/docs-publish-mkdocs.yml).
+This repo's `.github/workflows/docs-publish.yml` is a 5-line caller that
+pins to a specific version (`@v1.9.1` at time of writing). Upgrades happen
+in one place; consumers bump the pin to opt in.
+
+## Scaling rubric
+
+The starter `mkdocs.yml` ships with a 5-section nav (Home / Getting started
+/ Features / Platform support / Operations / Release). That's intentionally
+optimistic — most early-stage libraries shouldn't pre-create all of those.
+
+Start flat. Split a section only when it has **≥ 4 pages**. Use this rubric
+to choose the right structure for your library's current size:
+
+| Library shape | docs/ structure |
+|---------------|-----------------|
+| **1 module, < 5 pages** | Flat: `index.md`, `Home.md`, `getting-started.md`, `api.md`. No subdirs. `mkdocs.yml` nav = 4 entries. |
+| **1-2 modules, 5-15 pages** | Add `getting-started/` + `features/` subdirs. Keep operations + release inline as single pages until each grows to ≥ 4 pages. |
+| **2-5 modules, 15-30 pages** | Adopt the full starter nav (6 sections). Each section has its own subdir. Add a `platform-support/` matrix page. |
+| **5+ modules** | Introduce `docs/modules/<module>.md` per-module landing pages. Use `mkdocs-include-markdown-plugin` to mirror each module's source-tree README. Add a Modules section to nav. |
+| **Heavy how-to content** (≥ 10 task-oriented pages) | Introduce a `docs/cookbook/<topic>/<recipe>.md` structure. One page per task, named as a user question ("How do I X?"). See KmpToolkit for the live pattern. |
+| **Heavy API reference** | Don't try to render API ref in mkdocs. Bundle Dokka HTML inside `-javadoc.jar` (per-module `dokkaGeneratePublicationHtml` + `vanniktech.mavenPublish.JavadocJar.Dokka` config) and link to Maven Central from the mkdocs site. |
+
+Anti-pattern: pre-structuring for hypothetical growth. Empty sections
+(headings with one stub page) look unprofessional and add nav clutter.
+Three nav entries with content > seven nav entries half-filled.
+
+## Validation commands
+
+Exact CLI snippets agents can run without modification.
+
+```bash
+# Strict build (what CI runs)
+pip install -r docs/requirements.txt
+mkdocs build --strict
+
+# Live preview
+mkdocs serve  # → http://127.0.0.1:8000
+
+# List every WARNING / ERROR from a strict build (filter out INFO noise)
+mkdocs build --strict 2>&1 | grep -E "^(WARNING|ERROR)"
+
+# Count pages
+find docs -name "*.md" -not -path "*/stylesheets/*" | wc -l
+
+# Confirm Home.md and index.md are in sync (zero diff = OK)
+diff docs/Home.md docs/index.md && echo "OK: in sync"
+
+# Show current caller pin
+grep "docs-publish-mkdocs.yml@" .github/workflows/docs-publish.yml
+
+# Trigger deploy manually (workflow_dispatch)
+gh workflow run docs-publish.yml --ref development
+
+# Inspect Pages config (build_type should be "workflow")
+gh api repos/<org>/<repo>/pages --jq '"build_type: \(.build_type)\nstatus: \(.status)"'
+
+# Watch the most recent deploy run to completion
+gh run watch $(gh run list --workflow=docs-publish.yml --limit 1 --json databaseId -q '.[0].databaseId') --exit-status
+
+# Verify the site is live (after CDN propagation)
+curl -sI https://<org>.github.io/<repo>/ | head -1   # expect HTTP/2 200
+```
+
+When any of these fail, the corresponding fix is in the troubleshooting
+table above ("When the site breaks").
+
+## Project-specific extensions
+
+This file (`docs/DEVELOPMENT-TEMPLATE.md`) is generic and sync'd from the
+template — your library cannot edit it (next sync would clobber the change).
+
+When your library has conventions that don't fit the generic blueprint —
+a cookbook-recipe enforcement schema, a multi-module modules/ index, a
+release-cadence rubric, custom validators — author them in a sibling file
+named **`docs/DEVELOPMENT.md`**. That file:
+
+- Lives in your library only (NOT sync'd from the template)
+- Layers on top of this generic guide rather than replacing it
+- Should be linked from your library's `docs/DEVELOPMENT.md` to this one
+  as the "see also: generic guide"
+
+Examples of content that belongs in the per-project `DEVELOPMENT.md`, not here:
+
+- Cookbook recipe enforcement (line caps, mandatory code-block languages,
+  required frontmatter fields like `reviewed_by`)
+- Per-module page conventions (README-embed vs placeholder duality)
+- Legacy directory migration tasks
+- Library-specific validation commands (e.g. "every `cmp-*` module has a
+  matching `docs/modules/` page")
+- Custom mkdocs plugins or macros

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,198 @@
+# Docs authoring guide
+
+How to write, structure, and ship the documentation that lives under `docs/`.
+This guide is itself an example of the conventions it documents.
+
+## Two surfaces, one source
+
+Files in `docs/` feed **two** published surfaces:
+
+| Surface | Pipeline | Lands at |
+|---------|----------|----------|
+| **mkdocs site** (canonical) | `.github/workflows/docs-publish.yml` → `mbl-actionhub/docs-publish-mkdocs.yml` | `https://<org>.github.io/<repo>/` |
+| **GitHub Wiki** | `.github/workflows/sync-docs-to-wiki.yml` → `mbl-actionhub-docshub` composite | `https://github.com/<org>/<repo>/wiki/<basename>` |
+
+Both pipelines trigger on push to `development` whenever `docs/**` or `mkdocs.yml`
+changes. There is no "write once, sync later" step — the merge is the deploy.
+
+## Files with special meaning
+
+| File | Used by | Purpose |
+|------|---------|---------|
+| `index.md` | mkdocs | Root URL of the site (`/`). Required — without it the root returns 404. |
+| `Home.md` | wiki | Wiki's home page. GitHub Wiki indexes by basename; this name is hard-coded. Excluded from the mkdocs build (`exclude_docs:`) to avoid a duplicate `/Home/` page. |
+| `_Sidebar.md` | wiki | Wiki sidebar nav. Excluded from the mkdocs build. |
+| `requirements.txt` | docs-publish workflow | Pinned mkdocs deps — change a version here, not in the workflow. |
+| `stylesheets/mbs-brand.css` | mkdocs | Brand polish. Override colors for your library here. |
+
+`index.md` and `Home.md` are duplicates by design: mkdocs needs `index.md`,
+wiki needs `Home.md`, and they should always show the same landing content.
+When you edit one, edit the other.
+
+## Adding a new page (3-step)
+
+1. **Write the markdown** under the appropriate section directory
+   (`docs/<section>/<page-slug>.md`). Use kebab-case for filenames.
+2. **Register it in `mkdocs.yml`** under `nav:`. The section heading you put it
+   under is what appears in the site's tab bar.
+3. **Push to `development`** — the docs-publish workflow rebuilds and
+   redeploys the site within ~30 seconds.
+
+Wiki picks up the new file automatically (no nav registration needed —
+wiki uses `_Sidebar.md` for nav).
+
+## Section conventions
+
+The starter `mkdocs.yml` declares these sections. Use them or replace them,
+but keep the structure shallow (≤2 levels of nesting):
+
+| Section | What goes here |
+|---------|----------------|
+| **Home** | Library overview, badges, "why this exists" — same content as `index.md`/`Home.md`. |
+| **Getting started** | Install, first usage, key concepts, migration guides. Each page should be runnable end-to-end. |
+| **Features** | One page per top-level capability. Title each page as a noun phrase ("Foreground tasks"), not a verb ("How to run foreground tasks"). |
+| **Platform support** | Per-platform pages + matrix tables. Capture quirks, capabilities, and not-yet-supported APIs. |
+| **Operations** | Performance, security, audits, threat models — anything ops-oriented for production deployers. |
+| **Release** | Release process, postmortem template, deprecation policy. |
+
+## Style guide
+
+### Code blocks
+
+Always declare the language. mkdocs-material renders Kotlin, Swift, Bash, YAML,
+JSON, and TOML out of the box. Never leave a code block unlabeled.
+
+````markdown
+```kotlin
+val worker = MyWorker()
+```
+````
+
+Inline `code` for symbols + flag names. Use `**bold**` for first-mention
+emphasis of a concept (sparingly).
+
+### Admonitions
+
+Use admonitions (`!!! note`, `!!! warning`, `!!! tip`) for callouts that break
+the flow but are important. Don't use them for body text.
+
+```markdown
+!!! warning "iOS background time is finite"
+    BGTaskScheduler grants ~30s of execution. Long work needs
+    `URLSession.uploadTask` instead.
+```
+
+### Tables
+
+Use tables for any comparison with ≥3 dimensions (platforms × features,
+versions × behaviors, options × tradeoffs). Inline lists are fine for
+≤2 dimensions.
+
+### Links
+
+- **Internal** (within the docs/ tree): use relative paths
+  (`[Quick start](getting-started/quick-start.md)`). mkdocs validates these on
+  build; broken links surface as INFO-level warnings.
+- **External**: full URLs.
+- **Cross-repo source** (`workspaces/mbs/...`): the warning is INFO-level and
+  expected — the link works on GitHub source view but not on the docs site.
+- **API reference**: link to the published Dokka HTML (bundled inside each
+  module's `-javadoc.jar`) or to Maven Central.
+
+### Per-platform caveats
+
+When a feature behaves differently across platforms, structure as:
+
+```markdown
+## Per-platform notes
+
+- **Android:** ... 
+- **iOS:** ...
+- **JVM Desktop:** ...
+- **JS / wasmJs:** ...
+```
+
+This pattern is grep-friendly and reads consistently across the site.
+
+## Test locally before pushing
+
+```bash
+pip install -r docs/requirements.txt
+mkdocs serve
+# open http://127.0.0.1:8000
+```
+
+`mkdocs build --strict` is what CI runs. If strict fails locally, it'll fail
+in CI. Most common cause: a nav entry references a file that doesn't exist,
+or a relative link points outside `docs/`.
+
+## What NOT to do
+
+- **Don't hand-author files under `site/`** — that directory is the mkdocs
+  build output, regenerated on every deploy.
+- **Don't commit `.cache/` or generated assets** — `.gitignore` already
+  excludes them; if you see one in `git status`, fix the ignore instead of
+  staging it.
+- **Don't edit the workflow** to change build behavior. The build logic
+  lives in `mbl-actionhub/docs-publish-mkdocs.yml`. Bump the `@vX.Y.Z` pin
+  in `.github/workflows/docs-publish.yml` to upgrade.
+- **Don't add a `docs/CNAME` file** to set a custom domain — configure it
+  via the repo's Pages settings (UI or `gh api ... -f cname=...`).
+- **Don't author Liquid `{% ... %}` syntax** in markdown. The mkdocs site
+  doesn't process Liquid, but if Pages is ever misconfigured back to legacy
+  Jekyll it will fail to render those files.
+
+## Adding a new section to the nav
+
+Edit `mkdocs.yml` → `nav:` block. Each entry is `Section Title:` followed by
+either a single `page.md` or a nested list of pages. Keep section titles
+≤3 words; the navigation tab bar truncates long titles.
+
+```yaml
+nav:
+  - Home: index.md
+  - Getting started:
+      - Installation: getting-started/installation.md
+      - Quick start: getting-started/quick-start.md
+  - New section:
+      - First page: new-section/first-page.md
+```
+
+## Updating the brand
+
+`docs/stylesheets/mbs-brand.css` declares primary + accent colors via
+`--md-primary-fg-color` and `--md-accent-fg-color`. Change these to match
+your library's brand. Tweak typography spacing in the same file — keep
+changes small; mkdocs-material's defaults are well-considered.
+
+For the palette toggle (light/dark mode), edit `mkdocs.yml` → `theme.palette`.
+
+## When the site breaks
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `/` returns 404 | `docs/index.md` missing | Add it (duplicate of `Home.md`). |
+| Build fails: "unrecognized relative link" | A `*.md` link points outside `docs/` | Either fix the link or accept it (it'll surface as INFO, not error). |
+| Build fails: "nav references file that doesn't exist" | `mkdocs.yml` nav has a stale entry | Remove the entry or create the file. |
+| Pages deploy succeeds but site shows old content | CDN cache | Hard refresh (Cmd-Shift-R). Usually clears within 1-2 minutes. |
+| `configure-pages` errors with "Get Pages site failed" | Repo's Pages source not set to "GitHub Actions" | Bump caller workflow pin to `v1.9.1+` (auto-enables) OR flip Settings → Pages → Source manually. |
+
+## Wiki-specific notes
+
+- Wiki sync requires the wiki to be initialized (Settings → Features → Wikis
+  → enabled, then create any first page via the Wiki UI). Without this, the
+  composite errors with "Repository not found".
+- `_Sidebar.md` in `docs/` becomes the wiki's left nav. If you want wiki
+  auto-sidebar generation, set `sidebar-mode: auto` in the workflow inputs
+  (the default).
+- Wiki indexes by basename — two files named the same in different subdirs
+  collide. The docshub composite resolves by subdir-prefixing the slug, but
+  it's cleaner to avoid the collision in the first place.
+
+## Pipeline architecture (one-paragraph version)
+
+The build + deploy logic lives **once** in
+[`mbl-actionhub/docs-publish-mkdocs.yml`](https://github.com/MobileByteLabs/mbl-actionhub/blob/main/.github/workflows/docs-publish-mkdocs.yml).
+This repo's `.github/workflows/docs-publish.yml` is a 5-line caller that
+pins to a specific version (`@v1.9.1` at time of writing). Upgrades happen
+in one place; consumers bump the pin to opt in.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,48 +1,124 @@
-# Docs authoring guide (project-specific)
+---
+title: Docs guide (project)
+description: Per-project authoring extensions on top of the canonical DEVELOPMENT-TEMPLATE.md blueprint.
+---
 
-Project-specific extensions to the canonical authoring guide that lives in
-[`DEVELOPMENT-TEMPLATE.md`](DEVELOPMENT-TEMPLATE.md). Read the template
-file first — the conventions below assume that baseline.
+# Docs guide (project)
 
-This file is **owned by this repo**. It is NOT sync'd from
-`mbl-library-template-kmp` (only `DEVELOPMENT-TEMPLATE.md` is). Edit it
-freely to capture conventions specific to your library.
+!!! abstract "What this file is"
+    Per-project extensions on top of the canonical blueprint in
+    [`DEVELOPMENT-TEMPLATE.md`](DEVELOPMENT-TEMPLATE.md) — **read that first.**
 
-## When to put something here vs in DEVELOPMENT-TEMPLATE.md
+    Unlike the template file, this one is **owned by your repo**. It is NOT
+    sync'd from `mbl-library-template-kmp`. Edit it freely to capture
+    conventions specific to your library.
+
+!!! tip "When in doubt, default to the template"
+    If a convention applies to "any KMP library docs/," it belongs in
+    `DEVELOPMENT-TEMPLATE.md` (and should be PR'd against
+    `mbl-library-template-kmp`). Only library-specific overrides or
+    extensions go here.
+
+---
+
+## What goes here vs there
 
 | Belongs in `DEVELOPMENT-TEMPLATE.md` (generic) | Belongs in `DEVELOPMENT.md` (project) |
-|------------------------------------------------|----------------------------------------|
+|---|---|
 | How to add a page, section, image | Cookbook recipe enforcement (line caps, mandatory langs, frontmatter fields) |
 | Style guide (code blocks, admonitions, tables, links) | Per-module page conventions (README-embed flavor vs placeholder) |
-| Local preview command | Custom validators (e.g. "every `cmp-*` module has a `docs/modules/` page") |
-| Pipeline architecture explainer | Legacy directory migration plan |
+| Local preview + Material features | Library-specific validators (cross-checks specific to this repo) |
+| Pipeline architecture explainer | Legacy directory migration plan (per-repo) |
 | Generic agent recipes / invariants / validations | Library-specific recipes / invariants / scaling cues |
 | `Home.md` ↔ `index.md` dual-surface rule | Custom mkdocs plugins or macros |
 
+---
+
 ## Conventions for this library
 
-(Add sections here as your library's docs/ tree grows. Examples below are
-placeholders — delete or replace.)
+!!! info "This is a starter stub"
+    The sections below are placeholders for conventions that emerge as
+    your library grows. Delete the ones that don't apply; expand the
+    ones that do.
 
 ### Cookbook recipe format
 
-(If your library has a cookbook, document the enforced shape here — line
-cap, required frontmatter fields, required code-block languages, related
-links pattern.)
+??? note "If your library has a cookbook"
+    Document the enforced shape:
+
+    - Line cap (e.g. ≤ 80 lines)
+    - Required frontmatter fields (e.g. `reviewed_by.date`, `version`)
+    - Required code-block languages (e.g. ≥ 1 ` ```kotlin ` block)
+    - Title pattern (e.g. "How do I X?")
+    - Related-links structure
+
+    Reference the recipe template (typically `docs/_partials/cookbook-recipe-template.md`).
 
 ### Per-module page conventions
 
-(If your library has multiple modules with one page each, document the
-include-markdown pattern or placeholder fallback here.)
+??? note "If your library has multiple modules with one page each"
+    Document:
+
+    - Where the per-module pages live (`docs/modules/cmp-*.md`)
+    - The README-embed pattern (via `mkdocs-include-markdown-plugin`)
+    - The placeholder fallback for modules without a README yet
+    - The migration rule (when a module gains a README, convert its
+      placeholder in the same PR)
 
 ### Library-specific recipes
 
-(Add agent-actionable recipes that aren't covered by the generic guide.)
+??? note "Agent-actionable recipes not covered by the generic guide"
+    Examples:
+
+    - "Add a new module": (1) create the Gradle subproject (2) write
+      `cmp-<name>/README.md` (3) create `docs/modules/cmp-<name>.md`
+      (4) add to mkdocs nav (5) apply the Dokka convention plugin (6)
+      update CHANGELOG.
+
+    - "Migrate a legacy `docs/<module>/` subdir": (1) lift content
+      into `cmp-<module>/README.md` or cookbook recipes (2) delete the
+      legacy subdir (3) remove its line from `mkdocs.yml` →
+      `exclude_docs:`.
 
 ### Library-specific invariants
 
-(When X changes in your library, what else must change?)
+??? note "Cross-file edit obligations specific to this repo"
+    Examples:
+
+    - **New `cmp-<name>/` Gradle module** → 5 places must update in
+      the same PR: docs/modules/ landing page + mkdocs nav + Gradle
+      plugin + per-module CHANGELOG + root CHANGELOG.
+    - **Cookbook recipe verified against new release** → bump
+      `reviewed_by.date` + `version` in frontmatter.
+    - **Legacy subdir migrated** → remove its line from `exclude_docs:`.
 
 ### Library-specific validation
 
-(CLI snippets that audit conventions specific to this library.)
+??? note "CLI snippets that audit conventions specific to this library"
+    Examples:
+
+    ```bash
+    # Every cmp-* Gradle module has a docs/modules/ landing page
+    diff <(ls -1d cmp-*/) <(ls docs/modules/cmp-*.md | xargs -n1 basename)
+
+    # Every cookbook recipe ≤ 80 lines
+    for f in docs/cookbook/**/*.md; do
+      lines=$(wc -l < "$f")
+      [ "$lines" -gt 80 ] && echo "OVERLONG ($lines): $f"
+    done
+    ```
+
+---
+
+## Local preview
+
+The local preview command is the same as the generic guide:
+
+```bash
+pip install -r docs/requirements.txt
+mkdocs serve
+```
+
+If your library adds plugins beyond `mkdocs-material` (e.g.
+`mkdocs-include-markdown-plugin`, `mkdocs-macros-plugin`), pin them in
+`docs/requirements.txt` so contributors get the same versions CI runs.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,7 +1,47 @@
 # Docs authoring guide
 
 How to write, structure, and ship the documentation that lives under `docs/`.
-This guide is itself an example of the conventions it documents.
+This guide is itself an example of the conventions it documents. It serves
+two audiences: human contributors (read top to bottom) and AI agents
+(grep for the structured sections below — Agent quick reference,
+Invariants, Scaling rubric, Validation commands).
+
+## Agent quick reference
+
+Common operations as copy-paste recipes. Each row is the *complete* action;
+follow every step.
+
+| Want to… | Recipe |
+|----------|--------|
+| Add a narrative page | (1) Write `docs/<slug>.md` (2) Add `- <Title>: <slug>.md` under the right section in `mkdocs.yml` → `nav:` (3) `git add` both → commit |
+| Add a section | (1) `mkdir docs/<section>` (2) Author `docs/<section>/<first-page>.md` (3) Add `- <Section>:\n  - <Page>: <section>/<first-page>.md` block to `mkdocs.yml` → `nav:` |
+| Add an image / asset | (1) Drop into `docs/images/` (create if needed) (2) Reference as `![Alt](images/<file>)` from any page |
+| Override brand color | Edit `docs/stylesheets/mbs-brand.css` → `--md-primary-fg-color` (header/links) + `--md-accent-fg-color` (highlights, copy button) |
+| Test build locally | `pip install -r docs/requirements.txt && mkdocs build --strict` |
+| Live preview | `mkdocs serve` → open `http://127.0.0.1:8000` |
+| Upgrade docs pipeline | Bump `@vX.Y.Z` pin in `.github/workflows/docs-publish.yml` → next push redeploys via new version |
+| Trigger deploy manually | `gh workflow run docs-publish.yml --ref development` |
+| Investigate `/` 404 | Verify `docs/index.md` exists (mkdocs requires it for the root URL) |
+| Investigate site shows old content | Cmd-Shift-R (CDN); wait 1-2 min; if persistent, check Pages config: `gh api repos/<org>/<repo>/pages` |
+| Edit Home/index content | **Edit both** `docs/Home.md` and `docs/index.md` — they MUST stay in sync (see Invariants below) |
+| Disable Jekyll on Pages site | (Already done — `actions/configure-pages@v5` with `enablement: true` in reusable workflow at `v1.9.1+` handles this) |
+
+## Invariants
+
+When you touch the file in the first column, you MUST also update the
+files in the second column in the same commit (or the next push will break
+something).
+
+| If you change… | Also update… | Why |
+|----------------|--------------|-----|
+| `docs/Home.md` content | `docs/index.md` (mirror) | Wiki uses Home.md; mkdocs uses index.md. Divergence = surfaces show different content. |
+| `docs/index.md` content | `docs/Home.md` (mirror) | Same reason, reversed. |
+| Added a new `docs/<page>.md` (user-facing) | `mkdocs.yml` → `nav:` | Page exists on disk but no nav entry = invisible on site. |
+| New section directory | `mkdocs.yml` → `nav:` (new section block) | Same — directory contents don't appear without nav registration. |
+| Renamed a page | (1) Update all inbound `[link](old.md)` references (2) Optionally add a redirect via `mkdocs-redirects` plugin | Otherwise old URLs 404 and inbound links break. |
+| Deleted a page | (1) Remove from `mkdocs.yml` nav (2) Grep for inbound links + fix or delete them | Strict-mode build fails on dangling nav entries. |
+| Bumped `mkdocs-material` in `docs/requirements.txt` | Run `mkdocs build --strict` locally — Material can introduce theme breaks across minors | CI catches this, but you waste a deploy cycle if you skip local verification. |
+| Bumped caller pin (`@v1.9.1` → `@v1.10.x`) in `.github/workflows/docs-publish.yml` | Verify the new tag actually exists at `MobileByteLabs/mbl-actionhub` | Pinning a non-existent tag fails at workflow-resolution time. |
 
 ## Two surfaces, one source
 
@@ -196,3 +236,65 @@ The build + deploy logic lives **once** in
 This repo's `.github/workflows/docs-publish.yml` is a 5-line caller that
 pins to a specific version (`@v1.9.1` at time of writing). Upgrades happen
 in one place; consumers bump the pin to opt in.
+
+## Scaling rubric
+
+The starter `mkdocs.yml` ships with a 5-section nav (Home / Getting started
+/ Features / Platform support / Operations / Release). That's intentionally
+optimistic — most early-stage libraries shouldn't pre-create all of those.
+
+Start flat. Split a section only when it has **≥ 4 pages**. Use this rubric
+to choose the right structure for your library's current size:
+
+| Library shape | docs/ structure |
+|---------------|-----------------|
+| **1 module, < 5 pages** | Flat: `index.md`, `Home.md`, `getting-started.md`, `api.md`. No subdirs. `mkdocs.yml` nav = 4 entries. |
+| **1-2 modules, 5-15 pages** | Add `getting-started/` + `features/` subdirs. Keep operations + release inline as single pages until each grows to ≥ 4 pages. |
+| **2-5 modules, 15-30 pages** | Adopt the full starter nav (6 sections). Each section has its own subdir. Add a `platform-support/` matrix page. |
+| **5+ modules** | Introduce `docs/modules/<module>.md` per-module landing pages. Use `mkdocs-include-markdown-plugin` to mirror each module's source-tree README. Add a Modules section to nav. |
+| **Heavy how-to content** (≥ 10 task-oriented pages) | Introduce a `docs/cookbook/<topic>/<recipe>.md` structure. One page per task, named as a user question ("How do I X?"). See KmpToolkit for the live pattern. |
+| **Heavy API reference** | Don't try to render API ref in mkdocs. Bundle Dokka HTML inside `-javadoc.jar` (per-module `dokkaGeneratePublicationHtml` + `vanniktech.mavenPublish.JavadocJar.Dokka` config) and link to Maven Central from the mkdocs site. |
+
+Anti-pattern: pre-structuring for hypothetical growth. Empty sections
+(headings with one stub page) look unprofessional and add nav clutter.
+Three nav entries with content > seven nav entries half-filled.
+
+## Validation commands
+
+Exact CLI snippets agents can run without modification.
+
+```bash
+# Strict build (what CI runs)
+pip install -r docs/requirements.txt
+mkdocs build --strict
+
+# Live preview
+mkdocs serve  # → http://127.0.0.1:8000
+
+# List every WARNING / ERROR from a strict build (filter out INFO noise)
+mkdocs build --strict 2>&1 | grep -E "^(WARNING|ERROR)"
+
+# Count pages
+find docs -name "*.md" -not -path "*/stylesheets/*" | wc -l
+
+# Confirm Home.md and index.md are in sync (zero diff = OK)
+diff docs/Home.md docs/index.md && echo "OK: in sync"
+
+# Show current caller pin
+grep "docs-publish-mkdocs.yml@" .github/workflows/docs-publish.yml
+
+# Trigger deploy manually (workflow_dispatch)
+gh workflow run docs-publish.yml --ref development
+
+# Inspect Pages config (build_type should be "workflow")
+gh api repos/<org>/<repo>/pages --jq '"build_type: \(.build_type)\nstatus: \(.status)"'
+
+# Watch the most recent deploy run to completion
+gh run watch $(gh run list --workflow=docs-publish.yml --limit 1 --json databaseId -q '.[0].databaseId') --exit-status
+
+# Verify the site is live (after CDN propagation)
+curl -sI https://<org>.github.io/<repo>/ | head -1   # expect HTTP/2 200
+```
+
+When any of these fail, the corresponding fix is in the troubleshooting
+table above ("When the site breaks").

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,300 +1,48 @@
-# Docs authoring guide
-
-How to write, structure, and ship the documentation that lives under `docs/`.
-This guide is itself an example of the conventions it documents. It serves
-two audiences: human contributors (read top to bottom) and AI agents
-(grep for the structured sections below — Agent quick reference,
-Invariants, Scaling rubric, Validation commands).
-
-## Agent quick reference
-
-Common operations as copy-paste recipes. Each row is the *complete* action;
-follow every step.
-
-| Want to… | Recipe |
-|----------|--------|
-| Add a narrative page | (1) Write `docs/<slug>.md` (2) Add `- <Title>: <slug>.md` under the right section in `mkdocs.yml` → `nav:` (3) `git add` both → commit |
-| Add a section | (1) `mkdir docs/<section>` (2) Author `docs/<section>/<first-page>.md` (3) Add `- <Section>:\n  - <Page>: <section>/<first-page>.md` block to `mkdocs.yml` → `nav:` |
-| Add an image / asset | (1) Drop into `docs/images/` (create if needed) (2) Reference as `![Alt](images/<file>)` from any page |
-| Override brand color | Edit `docs/stylesheets/mbs-brand.css` → `--md-primary-fg-color` (header/links) + `--md-accent-fg-color` (highlights, copy button) |
-| Test build locally | `pip install -r docs/requirements.txt && mkdocs build --strict` |
-| Live preview | `mkdocs serve` → open `http://127.0.0.1:8000` |
-| Upgrade docs pipeline | Bump `@vX.Y.Z` pin in `.github/workflows/docs-publish.yml` → next push redeploys via new version |
-| Trigger deploy manually | `gh workflow run docs-publish.yml --ref development` |
-| Investigate `/` 404 | Verify `docs/index.md` exists (mkdocs requires it for the root URL) |
-| Investigate site shows old content | Cmd-Shift-R (CDN); wait 1-2 min; if persistent, check Pages config: `gh api repos/<org>/<repo>/pages` |
-| Edit Home/index content | **Edit both** `docs/Home.md` and `docs/index.md` — they MUST stay in sync (see Invariants below) |
-| Disable Jekyll on Pages site | (Already done — `actions/configure-pages@v5` with `enablement: true` in reusable workflow at `v1.9.1+` handles this) |
-
-## Invariants
-
-When you touch the file in the first column, you MUST also update the
-files in the second column in the same commit (or the next push will break
-something).
-
-| If you change… | Also update… | Why |
-|----------------|--------------|-----|
-| `docs/Home.md` content | `docs/index.md` (mirror) | Wiki uses Home.md; mkdocs uses index.md. Divergence = surfaces show different content. |
-| `docs/index.md` content | `docs/Home.md` (mirror) | Same reason, reversed. |
-| Added a new `docs/<page>.md` (user-facing) | `mkdocs.yml` → `nav:` | Page exists on disk but no nav entry = invisible on site. |
-| New section directory | `mkdocs.yml` → `nav:` (new section block) | Same — directory contents don't appear without nav registration. |
-| Renamed a page | (1) Update all inbound `[link](old.md)` references (2) Optionally add a redirect via `mkdocs-redirects` plugin | Otherwise old URLs 404 and inbound links break. |
-| Deleted a page | (1) Remove from `mkdocs.yml` nav (2) Grep for inbound links + fix or delete them | Strict-mode build fails on dangling nav entries. |
-| Bumped `mkdocs-material` in `docs/requirements.txt` | Run `mkdocs build --strict` locally — Material can introduce theme breaks across minors | CI catches this, but you waste a deploy cycle if you skip local verification. |
-| Bumped caller pin (`@v1.9.1` → `@v1.10.x`) in `.github/workflows/docs-publish.yml` | Verify the new tag actually exists at `MobileByteLabs/mbl-actionhub` | Pinning a non-existent tag fails at workflow-resolution time. |
-
-## Two surfaces, one source
-
-Files in `docs/` feed **two** published surfaces:
-
-| Surface | Pipeline | Lands at |
-|---------|----------|----------|
-| **mkdocs site** (canonical) | `.github/workflows/docs-publish.yml` → `mbl-actionhub/docs-publish-mkdocs.yml` | `https://<org>.github.io/<repo>/` |
-| **GitHub Wiki** | `.github/workflows/sync-docs-to-wiki.yml` → `mbl-actionhub-docshub` composite | `https://github.com/<org>/<repo>/wiki/<basename>` |
-
-Both pipelines trigger on push to `development` whenever `docs/**` or `mkdocs.yml`
-changes. There is no "write once, sync later" step — the merge is the deploy.
-
-## Files with special meaning
-
-| File | Used by | Purpose |
-|------|---------|---------|
-| `index.md` | mkdocs | Root URL of the site (`/`). Required — without it the root returns 404. |
-| `Home.md` | wiki | Wiki's home page. GitHub Wiki indexes by basename; this name is hard-coded. Excluded from the mkdocs build (`exclude_docs:`) to avoid a duplicate `/Home/` page. |
-| `_Sidebar.md` | wiki | Wiki sidebar nav. Excluded from the mkdocs build. |
-| `requirements.txt` | docs-publish workflow | Pinned mkdocs deps — change a version here, not in the workflow. |
-| `stylesheets/mbs-brand.css` | mkdocs | Brand polish. Override colors for your library here. |
-
-`index.md` and `Home.md` are duplicates by design: mkdocs needs `index.md`,
-wiki needs `Home.md`, and they should always show the same landing content.
-When you edit one, edit the other.
-
-## Adding a new page (3-step)
-
-1. **Write the markdown** under the appropriate section directory
-   (`docs/<section>/<page-slug>.md`). Use kebab-case for filenames.
-2. **Register it in `mkdocs.yml`** under `nav:`. The section heading you put it
-   under is what appears in the site's tab bar.
-3. **Push to `development`** — the docs-publish workflow rebuilds and
-   redeploys the site within ~30 seconds.
-
-Wiki picks up the new file automatically (no nav registration needed —
-wiki uses `_Sidebar.md` for nav).
-
-## Section conventions
-
-The starter `mkdocs.yml` declares these sections. Use them or replace them,
-but keep the structure shallow (≤2 levels of nesting):
-
-| Section | What goes here |
-|---------|----------------|
-| **Home** | Library overview, badges, "why this exists" — same content as `index.md`/`Home.md`. |
-| **Getting started** | Install, first usage, key concepts, migration guides. Each page should be runnable end-to-end. |
-| **Features** | One page per top-level capability. Title each page as a noun phrase ("Foreground tasks"), not a verb ("How to run foreground tasks"). |
-| **Platform support** | Per-platform pages + matrix tables. Capture quirks, capabilities, and not-yet-supported APIs. |
-| **Operations** | Performance, security, audits, threat models — anything ops-oriented for production deployers. |
-| **Release** | Release process, postmortem template, deprecation policy. |
-
-## Style guide
-
-### Code blocks
-
-Always declare the language. mkdocs-material renders Kotlin, Swift, Bash, YAML,
-JSON, and TOML out of the box. Never leave a code block unlabeled.
-
-````markdown
-```kotlin
-val worker = MyWorker()
-```
-````
-
-Inline `code` for symbols + flag names. Use `**bold**` for first-mention
-emphasis of a concept (sparingly).
+# Docs authoring guide (project-specific)
 
-### Admonitions
-
-Use admonitions (`!!! note`, `!!! warning`, `!!! tip`) for callouts that break
-the flow but are important. Don't use them for body text.
-
-```markdown
-!!! warning "iOS background time is finite"
-    BGTaskScheduler grants ~30s of execution. Long work needs
-    `URLSession.uploadTask` instead.
-```
-
-### Tables
-
-Use tables for any comparison with ≥3 dimensions (platforms × features,
-versions × behaviors, options × tradeoffs). Inline lists are fine for
-≤2 dimensions.
-
-### Links
-
-- **Internal** (within the docs/ tree): use relative paths
-  (`[Quick start](getting-started/quick-start.md)`). mkdocs validates these on
-  build; broken links surface as INFO-level warnings.
-- **External**: full URLs.
-- **Cross-repo source** (`workspaces/mbs/...`): the warning is INFO-level and
-  expected — the link works on GitHub source view but not on the docs site.
-- **API reference**: link to the published Dokka HTML (bundled inside each
-  module's `-javadoc.jar`) or to Maven Central.
-
-### Per-platform caveats
-
-When a feature behaves differently across platforms, structure as:
-
-```markdown
-## Per-platform notes
-
-- **Android:** ... 
-- **iOS:** ...
-- **JVM Desktop:** ...
-- **JS / wasmJs:** ...
-```
-
-This pattern is grep-friendly and reads consistently across the site.
-
-## Test locally before pushing
-
-```bash
-pip install -r docs/requirements.txt
-mkdocs serve
-# open http://127.0.0.1:8000
-```
-
-`mkdocs build --strict` is what CI runs. If strict fails locally, it'll fail
-in CI. Most common cause: a nav entry references a file that doesn't exist,
-or a relative link points outside `docs/`.
-
-## What NOT to do
-
-- **Don't hand-author files under `site/`** — that directory is the mkdocs
-  build output, regenerated on every deploy.
-- **Don't commit `.cache/` or generated assets** — `.gitignore` already
-  excludes them; if you see one in `git status`, fix the ignore instead of
-  staging it.
-- **Don't edit the workflow** to change build behavior. The build logic
-  lives in `mbl-actionhub/docs-publish-mkdocs.yml`. Bump the `@vX.Y.Z` pin
-  in `.github/workflows/docs-publish.yml` to upgrade.
-- **Don't add a `docs/CNAME` file** to set a custom domain — configure it
-  via the repo's Pages settings (UI or `gh api ... -f cname=...`).
-- **Don't author Liquid `{% ... %}` syntax** in markdown. The mkdocs site
-  doesn't process Liquid, but if Pages is ever misconfigured back to legacy
-  Jekyll it will fail to render those files.
-
-## Adding a new section to the nav
-
-Edit `mkdocs.yml` → `nav:` block. Each entry is `Section Title:` followed by
-either a single `page.md` or a nested list of pages. Keep section titles
-≤3 words; the navigation tab bar truncates long titles.
-
-```yaml
-nav:
-  - Home: index.md
-  - Getting started:
-      - Installation: getting-started/installation.md
-      - Quick start: getting-started/quick-start.md
-  - New section:
-      - First page: new-section/first-page.md
-```
+Project-specific extensions to the canonical authoring guide that lives in
+[`DEVELOPMENT-TEMPLATE.md`](DEVELOPMENT-TEMPLATE.md). Read the template
+file first — the conventions below assume that baseline.
 
-## Updating the brand
+This file is **owned by this repo**. It is NOT sync'd from
+`mbl-library-template-kmp` (only `DEVELOPMENT-TEMPLATE.md` is). Edit it
+freely to capture conventions specific to your library.
 
-`docs/stylesheets/mbs-brand.css` declares primary + accent colors via
-`--md-primary-fg-color` and `--md-accent-fg-color`. Change these to match
-your library's brand. Tweak typography spacing in the same file — keep
-changes small; mkdocs-material's defaults are well-considered.
+## When to put something here vs in DEVELOPMENT-TEMPLATE.md
 
-For the palette toggle (light/dark mode), edit `mkdocs.yml` → `theme.palette`.
+| Belongs in `DEVELOPMENT-TEMPLATE.md` (generic) | Belongs in `DEVELOPMENT.md` (project) |
+|------------------------------------------------|----------------------------------------|
+| How to add a page, section, image | Cookbook recipe enforcement (line caps, mandatory langs, frontmatter fields) |
+| Style guide (code blocks, admonitions, tables, links) | Per-module page conventions (README-embed flavor vs placeholder) |
+| Local preview command | Custom validators (e.g. "every `cmp-*` module has a `docs/modules/` page") |
+| Pipeline architecture explainer | Legacy directory migration plan |
+| Generic agent recipes / invariants / validations | Library-specific recipes / invariants / scaling cues |
+| `Home.md` ↔ `index.md` dual-surface rule | Custom mkdocs plugins or macros |
 
-## When the site breaks
+## Conventions for this library
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| `/` returns 404 | `docs/index.md` missing | Add it (duplicate of `Home.md`). |
-| Build fails: "unrecognized relative link" | A `*.md` link points outside `docs/` | Either fix the link or accept it (it'll surface as INFO, not error). |
-| Build fails: "nav references file that doesn't exist" | `mkdocs.yml` nav has a stale entry | Remove the entry or create the file. |
-| Pages deploy succeeds but site shows old content | CDN cache | Hard refresh (Cmd-Shift-R). Usually clears within 1-2 minutes. |
-| `configure-pages` errors with "Get Pages site failed" | Repo's Pages source not set to "GitHub Actions" | Bump caller workflow pin to `v1.9.1+` (auto-enables) OR flip Settings → Pages → Source manually. |
+(Add sections here as your library's docs/ tree grows. Examples below are
+placeholders — delete or replace.)
 
-## Wiki-specific notes
+### Cookbook recipe format
 
-- Wiki sync requires the wiki to be initialized (Settings → Features → Wikis
-  → enabled, then create any first page via the Wiki UI). Without this, the
-  composite errors with "Repository not found".
-- `_Sidebar.md` in `docs/` becomes the wiki's left nav. If you want wiki
-  auto-sidebar generation, set `sidebar-mode: auto` in the workflow inputs
-  (the default).
-- Wiki indexes by basename — two files named the same in different subdirs
-  collide. The docshub composite resolves by subdir-prefixing the slug, but
-  it's cleaner to avoid the collision in the first place.
+(If your library has a cookbook, document the enforced shape here — line
+cap, required frontmatter fields, required code-block languages, related
+links pattern.)
 
-## Pipeline architecture (one-paragraph version)
+### Per-module page conventions
 
-The build + deploy logic lives **once** in
-[`mbl-actionhub/docs-publish-mkdocs.yml`](https://github.com/MobileByteLabs/mbl-actionhub/blob/main/.github/workflows/docs-publish-mkdocs.yml).
-This repo's `.github/workflows/docs-publish.yml` is a 5-line caller that
-pins to a specific version (`@v1.9.1` at time of writing). Upgrades happen
-in one place; consumers bump the pin to opt in.
+(If your library has multiple modules with one page each, document the
+include-markdown pattern or placeholder fallback here.)
 
-## Scaling rubric
+### Library-specific recipes
 
-The starter `mkdocs.yml` ships with a 5-section nav (Home / Getting started
-/ Features / Platform support / Operations / Release). That's intentionally
-optimistic — most early-stage libraries shouldn't pre-create all of those.
+(Add agent-actionable recipes that aren't covered by the generic guide.)
 
-Start flat. Split a section only when it has **≥ 4 pages**. Use this rubric
-to choose the right structure for your library's current size:
+### Library-specific invariants
 
-| Library shape | docs/ structure |
-|---------------|-----------------|
-| **1 module, < 5 pages** | Flat: `index.md`, `Home.md`, `getting-started.md`, `api.md`. No subdirs. `mkdocs.yml` nav = 4 entries. |
-| **1-2 modules, 5-15 pages** | Add `getting-started/` + `features/` subdirs. Keep operations + release inline as single pages until each grows to ≥ 4 pages. |
-| **2-5 modules, 15-30 pages** | Adopt the full starter nav (6 sections). Each section has its own subdir. Add a `platform-support/` matrix page. |
-| **5+ modules** | Introduce `docs/modules/<module>.md` per-module landing pages. Use `mkdocs-include-markdown-plugin` to mirror each module's source-tree README. Add a Modules section to nav. |
-| **Heavy how-to content** (≥ 10 task-oriented pages) | Introduce a `docs/cookbook/<topic>/<recipe>.md` structure. One page per task, named as a user question ("How do I X?"). See KmpToolkit for the live pattern. |
-| **Heavy API reference** | Don't try to render API ref in mkdocs. Bundle Dokka HTML inside `-javadoc.jar` (per-module `dokkaGeneratePublicationHtml` + `vanniktech.mavenPublish.JavadocJar.Dokka` config) and link to Maven Central from the mkdocs site. |
+(When X changes in your library, what else must change?)
 
-Anti-pattern: pre-structuring for hypothetical growth. Empty sections
-(headings with one stub page) look unprofessional and add nav clutter.
-Three nav entries with content > seven nav entries half-filled.
+### Library-specific validation
 
-## Validation commands
-
-Exact CLI snippets agents can run without modification.
-
-```bash
-# Strict build (what CI runs)
-pip install -r docs/requirements.txt
-mkdocs build --strict
-
-# Live preview
-mkdocs serve  # → http://127.0.0.1:8000
-
-# List every WARNING / ERROR from a strict build (filter out INFO noise)
-mkdocs build --strict 2>&1 | grep -E "^(WARNING|ERROR)"
-
-# Count pages
-find docs -name "*.md" -not -path "*/stylesheets/*" | wc -l
-
-# Confirm Home.md and index.md are in sync (zero diff = OK)
-diff docs/Home.md docs/index.md && echo "OK: in sync"
-
-# Show current caller pin
-grep "docs-publish-mkdocs.yml@" .github/workflows/docs-publish.yml
-
-# Trigger deploy manually (workflow_dispatch)
-gh workflow run docs-publish.yml --ref development
-
-# Inspect Pages config (build_type should be "workflow")
-gh api repos/<org>/<repo>/pages --jq '"build_type: \(.build_type)\nstatus: \(.status)"'
-
-# Watch the most recent deploy run to completion
-gh run watch $(gh run list --workflow=docs-publish.yml --limit 1 --json databaseId -q '.[0].databaseId') --exit-status
-
-# Verify the site is live (after CDN propagation)
-curl -sI https://<org>.github.io/<repo>/ | head -1   # expect HTTP/2 200
-```
-
-When any of these fail, the corresponding fix is in the troubleshooting
-table above ("When the site breaks").
+(CLI snippets that audit conventions specific to this library.)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,35 +1,44 @@
+---
+title: TEMPLATE_LIBRARY_NAME
+description: TEMPLATE_DESCRIPTION
+---
+
 # TEMPLATE_LIBRARY_NAME
 
 > TEMPLATE_DESCRIPTION
 
-This is the documentation site for your library. Replace this content with
-your own. The mkdocs site is configured in `mkdocs.yml` at the repo root.
+!!! abstract "Welcome to your library's docs site"
+    After `customizer.sh` rebrands this template, replace this placeholder
+    with your library's overview — value proposition, hero diagram or
+    screenshot, primary use case in 1-2 sentences.
 
 ## Quick start
 
 ```kotlin
 // Replace this snippet with your library's smallest meaningful API.
+// Goal: ≤ 10 lines of copy-paste-runnable code demonstrating the single
+// most important capability.
 ```
 
-## Sections
+## Where to go next
 
-- **Getting started** — install, first usage, key concepts
-- **Features** — one page per top-level capability
-- **Platform support** — Android, iOS, Desktop, Web matrices
-- **Operations** — performance, security, parity audits
-- **Release** — release process, postmortem template
+- [Getting started](getting-started/installation.md) — install + first usage
+- [Features](features/) — one page per top-level capability
+- [Platform support](platform-support/) — Android, iOS, Desktop, Web matrices
 
-## Adding pages
+## Authoring docs
 
-1. Drop the markdown file under `docs/<section>/<page>.md`
-2. Register it in `mkdocs.yml` → `nav:`
-3. Push to `development` — the `docs-publish.yml` workflow rebuilds and
-   redeploys the site automatically (see `.github/workflows/docs-publish.yml`)
+The site is built with [mkdocs-material](https://squidfunk.github.io/mkdocs-material/).
+Authoring conventions live in:
 
-## Local preview
+- [`DEVELOPMENT-TEMPLATE.md`](DEVELOPMENT-TEMPLATE.md) — generic blueprint (sync'd from `mbl-library-template-kmp`)
+- [`DEVELOPMENT.md`](DEVELOPMENT.md) — per-library extensions (owned by this repo)
 
 ```bash
 pip install -r docs/requirements.txt
-mkdocs serve
-# open http://127.0.0.1:8000
+mkdocs serve   # → http://127.0.0.1:8000
 ```
+
+!!! tip "Both `index.md` and `Home.md` exist on purpose"
+    mkdocs uses `index.md` for the root URL; the GitHub Wiki uses `Home.md`
+    for its landing page. Edit both with the same content in every commit.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,35 +1,44 @@
+---
+title: TEMPLATE_LIBRARY_NAME
+description: TEMPLATE_DESCRIPTION
+---
+
 # TEMPLATE_LIBRARY_NAME
 
 > TEMPLATE_DESCRIPTION
 
-This is the documentation site for your library. Replace this content with
-your own. The mkdocs site is configured in `mkdocs.yml` at the repo root.
+!!! abstract "Welcome to your library's docs site"
+    After `customizer.sh` rebrands this template, replace this placeholder
+    with your library's overview — value proposition, hero diagram or
+    screenshot, primary use case in 1-2 sentences.
 
 ## Quick start
 
 ```kotlin
 // Replace this snippet with your library's smallest meaningful API.
+// Goal: ≤ 10 lines of copy-paste-runnable code demonstrating the single
+// most important capability.
 ```
 
-## Sections
+## Where to go next
 
-- **Getting started** — install, first usage, key concepts
-- **Features** — one page per top-level capability
-- **Platform support** — Android, iOS, Desktop, Web matrices
-- **Operations** — performance, security, parity audits
-- **Release** — release process, postmortem template
+- [Getting started](getting-started/installation.md) — install + first usage
+- [Features](features/) — one page per top-level capability
+- [Platform support](platform-support/) — Android, iOS, Desktop, Web matrices
 
-## Adding pages
+## Authoring docs
 
-1. Drop the markdown file under `docs/<section>/<page>.md`
-2. Register it in `mkdocs.yml` → `nav:`
-3. Push to `development` — the `docs-publish.yml` workflow rebuilds and
-   redeploys the site automatically (see `.github/workflows/docs-publish.yml`)
+The site is built with [mkdocs-material](https://squidfunk.github.io/mkdocs-material/).
+Authoring conventions live in:
 
-## Local preview
+- [`DEVELOPMENT-TEMPLATE.md`](DEVELOPMENT-TEMPLATE.md) — generic blueprint (sync'd from `mbl-library-template-kmp`)
+- [`DEVELOPMENT.md`](DEVELOPMENT.md) — per-library extensions (owned by this repo)
 
 ```bash
 pip install -r docs/requirements.txt
-mkdocs serve
-# open http://127.0.0.1:8000
+mkdocs serve   # → http://127.0.0.1:8000
 ```
+
+!!! tip "Both `index.md` and `Home.md` exist on purpose"
+    mkdocs uses `index.md` for the root URL; the GitHub Wiki uses `Home.md`
+    for its landing page. Edit both with the same content in every commit.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,8 @@ validation:
 # Release. Drop the ones you don't need.
 nav:
   - Home: index.md
+  - Contributing:
+      - Docs authoring guide: DEVELOPMENT.md
   # - Getting started:
   #     - Installation: getting-started/installation.md
   #     - Quick start: getting-started/quick-start.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,7 +73,8 @@ validation:
 nav:
   - Home: index.md
   - Contributing:
-      - Docs authoring guide: DEVELOPMENT.md
+      - Docs guide (template): DEVELOPMENT-TEMPLATE.md
+      - Docs guide (project): DEVELOPMENT.md
   # - Getting started:
   #     - Installation: getting-started/installation.md
   #     - Quick start: getting-started/quick-start.md

--- a/sync-dirs.sh
+++ b/sync-dirs.sh
@@ -35,12 +35,17 @@ SYNC_FILES=(
     "ci-prepush.sh"
     "build.gradle.kts"
     "gradle.properties"
+    "docs/DEVELOPMENT-TEMPLATE.md"
 )
-# Note: mkdocs.yml is intentionally NOT sync'd — each consumer customizes
-# site_name / nav / palette after customizer.sh runs. The .github/workflows/
-# docs-publish.yml caller IS auto-sync'd via the SYNC_DIRS '.github' entry,
-# so upstream version-pin bumps (actionhub@v1.9.0 → v1.10.0) propagate
-# automatically.
+# Notes:
+# - mkdocs.yml is intentionally NOT sync'd — each consumer customizes
+#   site_name / nav / palette after customizer.sh runs.
+# - docs/DEVELOPMENT.md is intentionally NOT sync'd — that's the per-project
+#   authoring guide owned by each consumer (extensions on top of the generic
+#   DEVELOPMENT-TEMPLATE.md). Only DEVELOPMENT-TEMPLATE.md (above) is sync'd.
+# - The .github/workflows/docs-publish.yml caller IS auto-sync'd via the
+#   SYNC_DIRS '.github' entry, so upstream version-pin bumps (actionhub@v1.9.0
+#   → v1.10.0) propagate automatically.
 
 # Define exclusions for directories and files
 # Format: "path/to/exclude:type"


### PR DESCRIPTION
## Summary
- Adds `docs/DEVELOPMENT.md` — canonical guide for writing the docs/ tree
- Wired into mkdocs nav under "Contributing → Docs authoring guide"
- No `TEMPLATE_*` placeholders; consumers bootstrapped via `customizer.sh` inherit it as-is

## What's in the guide
- The dual-surface contract (mkdocs site + GitHub Wiki) and special files (`index.md`, `Home.md`, `_Sidebar.md`)
- How to add a new page (3-step recipe)
- Section conventions matching the starter nav
- Style guide: code blocks, admonitions, tables, links, per-platform caveat pattern
- Local preview workflow + what `mkdocs build --strict` catches
- "What NOT to do" + a troubleshooting table for common breakages
- Wiki-specific notes
- One-paragraph explainer of the `mbl-actionhub` pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation authoring guide covering contribution workflows, documentation structure, style conventions, local testing procedures, and troubleshooting guidance.
  * Updated navigation menu to include the new contributing guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->